### PR TITLE
Rename `wal_keep_segments` to `wal_keep_size` for PG 13

### DIFF
--- a/role_scripts/13/primary/start.sh
+++ b/role_scripts/13/primary/start.sh
@@ -24,7 +24,7 @@ echo "max_wal_senders = 90" >>/tmp/postgresql.conf # default is 10.  value must 
 if [ ! -z "${WAL_RETAIN_PARAM:-}" ] && [ ! -z "${WAL_RETAIN_AMOUNT:-}" ]; then
     echo "${WAL_RETAIN_PARAM}=${WAL_RETAIN_AMOUNT}" >>/tmp/postgresql.conf
 else
-  echo "wal_keep_segments = 64" >>/tmp/postgresql.conf
+  echo "wal_keep_size = 64" >>/tmp/postgresql.conf
 fi
 echo "max_replication_slots = 90" >>/tmp/postgresql.conf
 echo "wal_log_hints = on" >>/tmp/postgresql.conf


### PR DESCRIPTION
Was inadvertently flipped in the 0.12.0 release.
