### PR TITLE
Support pg_tde Transparent Data Encryption in init scripts

### DIFF
--- a/role_scripts/10/primary/start.sh
+++ b/role_scripts/10/primary/start.sh
@@ -35,7 +35,11 @@ echo "max_replication_slots = 90" >>/tmp/postgresql.conf
 echo "wal_log_hints = on" >>/tmp/postgresql.conf
 echo "archive_mode = always" >>/tmp/postgresql.conf
 echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 
 if [[ "${SSL:-0}" == "ON" ]]; then
     echo "ssl =on" >>/tmp/postgresql.conf
@@ -87,6 +91,45 @@ echo
 
 psql+=(--username "$POSTGRES_USER" --dbname "$POSTGRES_DB")
 echo
+
+# pg_tde principal-key bootstrap. Runs once on first initialization, after the
+# database and superuser exist and before any encrypted table or the
+# default_table_access_method flip can be used. Idempotent on retries.
+if [[ "${TDE_ENABLED:-false}" == "true" && "${BOOTSTRAP}" == "true" ]]; then
+    # Enable the extension in the default databases. template1 makes it the
+    # default for future databases.
+    for TDE_DB in template1 "$POSTGRES_DB"; do
+        psql -U postgres -d "$TDE_DB" -v ON_ERROR_STOP=1 <<SQL
+CREATE EXTENSION IF NOT EXISTS ${TDE_EXTENSION:-pg_tde};
+SQL
+    done
+
+    # Register the key provider (global preferred; file is standalone only).
+    case "${TDE_PROVIDER_KIND:-}" in
+        vault)
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_add_global_key_provider_vault_v2('${TDE_PROVIDER_NAME}','${TDE_VAULT_ADDR}','${TDE_VAULT_MOUNT}','${TDE_VAULT_TOKEN_PATH}','${TDE_VAULT_CA_PATH}');" || true
+            ;;
+        kmip)
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_add_global_key_provider_kmip('${TDE_PROVIDER_NAME}','${TDE_KMIP_ADDR}',${TDE_KMIP_PORT},'${TDE_KMIP_CLIENT_CERT_PATH}','${TDE_KMIP_CLIENT_KEY_PATH}','${TDE_KMIP_CA_PATH}');" || true
+            ;;
+        file)
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_add_database_key_provider_file('${TDE_PROVIDER_NAME}','${TDE_FILE_PATH}');" || true
+            ;;
+    esac
+
+    # Set the per-database principal key.
+    psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+
+    # If WAL encryption is requested, set the server key too (global only).
+    if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_server_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" || true
+    fi
+fi
 
 if [[ "$BOOTSTRAP" == "true" ]];then
   # initialize database
@@ -172,6 +215,14 @@ fi
 mv /tmp/pg_hba.conf "$PGDATA/pg_hba.conf"
 
 touch /tmp/postgresql.conf
+# pg_tde runtime GUCs. Authored in the post-bootstrap rewrite, after the
+# extension and principal key exist, so default_table_access_method is safe.
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 if [ "$STANDBY" == "hot" ]; then
     echo "hot_standby = on" >>/tmp/postgresql.conf
 else
@@ -212,4 +263,3 @@ if [[ "$STREAMING" == "synchronous" ]]; then
 fi
 # ref: https://superuser.com/a/246841/985093
 cat /tmp/postgresql.conf $PGDATA/postgresql.conf >"/tmp/postgresql.conf.tmp" && mv "/tmp/postgresql.conf.tmp" "$PGDATA/postgresql.conf"
-

--- a/role_scripts/10/primary/start.sh
+++ b/role_scripts/10/primary/start.sh
@@ -96,6 +96,10 @@ echo
 # database and superuser exist and before any encrypted table or the
 # default_table_access_method flip can be used. Idempotent on retries.
 if [[ "${TDE_ENABLED:-false}" == "true" && "${BOOTSTRAP}" == "true" ]]; then
+    # Run every pg_tde key operation in this block at the configured cipher. The
+    # post-bootstrap config that carries pg_tde.cipher is not loaded yet, so without
+    # this the principal key would be created (and validated) at the wrong length.
+    export PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}"
     # Enable the extension in the default databases. template1 makes it the
     # default for future databases.
     for TDE_DB in template1 "$POSTGRES_DB"; do
@@ -126,14 +130,14 @@ SQL
     # Key setup is strict: a failure fails the bootstrap loudly rather than booting
     # with no principal key, which would silently break encrypted-table creation.
     if [[ "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
-        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || { echo "pg_tde FATAL: failed to set database principal key '${TDE_KEY_NAME}'"; exit 1; }
     else
-        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
@@ -143,7 +147,7 @@ SQL
 
     # If WAL encryption is requested, create + set the server (WAL) key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
-        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create WAL server key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
@@ -151,6 +155,8 @@ SQL
             || { echo "pg_tde FATAL: failed to set WAL server key '${TDE_KEY_NAME}-wal'"; exit 1; }
     fi
 fi
+
+unset PGOPTIONS
 
 if [[ "$BOOTSTRAP" == "true" ]];then
   # initialize database

--- a/role_scripts/10/primary/start.sh
+++ b/role_scripts/10/primary/start.sh
@@ -157,6 +157,13 @@ SQL
             || tde_bootstrap_fatal "failed to set global principal key '${TDE_KEY_NAME}'"
     fi
 
+    # WAL encryption is global-only: the file keyring is a database-scoped
+    # provider and cannot back a server key. The operator webhook already rejects
+    # this combination, so this is a fail-closed backstop with a clear message
+    # (instead of a swallowed error that crash-loops on the misleading set-key fatal).
+    if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" && "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
+        tde_bootstrap_fatal "WAL encryption requires a global (vault or kmip) key provider; the file keyring cannot back WAL encryption"
+    fi
     # If WAL encryption is requested, create + set the server (WAL) key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \

--- a/role_scripts/10/primary/start.sh
+++ b/role_scripts/10/primary/start.sh
@@ -100,6 +100,18 @@ if [[ "${TDE_ENABLED:-false}" == "true" && "${BOOTSTRAP}" == "true" ]]; then
     # post-bootstrap config that carries pg_tde.cipher is not loaded yet, so without
     # this the principal key would be created (and validated) at the wrong length.
     export PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}"
+    # tde_bootstrap_fatal aborts a failed first-time TDE bootstrap loudly. This runs
+    # only during initial initialization (BOOTSTRAP=true), so there is no user data
+    # yet; wipe the half-initialized data dir and exit non-zero. That forces a full
+    # re-bootstrap on the next start instead of falling through to a keyless boot
+    # (which would silently disable encryption). The pod crash-loops visibly until
+    # the key provider is reachable.
+    tde_bootstrap_fatal() {
+        echo "pg_tde FATAL: $1"
+        pg_ctl -D "$PGDATA" -m immediate -w stop || true
+        rm -rf "${PGDATA:?}"/* || true
+        exit 1
+    }
     # Enable the extension in the default databases. template1 makes it the
     # default for future databases.
     for TDE_DB in template1 "$POSTGRES_DB"; do
@@ -135,14 +147,14 @@ SQL
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
-            || { echo "pg_tde FATAL: failed to set database principal key '${TDE_KEY_NAME}'"; exit 1; }
+            || tde_bootstrap_fatal "failed to set database principal key '${TDE_KEY_NAME}'"
     else
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
-            || { echo "pg_tde FATAL: failed to set global principal key '${TDE_KEY_NAME}'"; exit 1; }
+            || tde_bootstrap_fatal "failed to set global principal key '${TDE_KEY_NAME}'"
     fi
 
     # If WAL encryption is requested, create + set the server (WAL) key too (global only).
@@ -152,7 +164,7 @@ SQL
             || echo "pg_tde: create WAL server key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_server_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
-            || { echo "pg_tde FATAL: failed to set WAL server key '${TDE_KEY_NAME}-wal'"; exit 1; }
+            || tde_bootstrap_fatal "failed to set WAL server key '${TDE_KEY_NAME}-wal'"
     fi
 fi
 

--- a/role_scripts/10/primary/start.sh
+++ b/role_scripts/10/primary/start.sh
@@ -120,20 +120,35 @@ SQL
             ;;
     esac
 
-    # Set the per-database principal key with the setter that matches the
-    # provider scope: file providers are database-scoped, vault/kmip are global.
+    # Create then set the per-database principal key. pg_tde requires the key to
+    # exist before it can be set as principal, so create precedes set. The setter
+    # matches the provider scope (file is database-scoped, vault/kmip are global).
+    # Key setup is strict: a failure fails the bootstrap loudly rather than booting
+    # with no principal key, which would silently break encrypted-table creation.
     if [[ "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+            "SELECT pg_tde_create_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
+            || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
+            || { echo "pg_tde FATAL: failed to set database principal key '${TDE_KEY_NAME}'"; exit 1; }
     else
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+            "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
+            || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
+            || { echo "pg_tde FATAL: failed to set global principal key '${TDE_KEY_NAME}'"; exit 1; }
     fi
 
-    # If WAL encryption is requested, set the server key too (global only).
+    # If WAL encryption is requested, create + set the server (WAL) key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_set_server_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" || true
+            "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
+            || echo "pg_tde: create WAL server key returned non-zero (may already exist), continuing to set"
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_server_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
+            || { echo "pg_tde FATAL: failed to set WAL server key '${TDE_KEY_NAME}-wal'"; exit 1; }
     fi
 fi
 

--- a/role_scripts/10/primary/start.sh
+++ b/role_scripts/10/primary/start.sh
@@ -155,6 +155,22 @@ SQL
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || tde_bootstrap_fatal "failed to set global principal key '${TDE_KEY_NAME}'"
+
+        # Set a server-wide DEFAULT principal key so databases created later inherit
+        # encryption. pg_tde stores the principal key per database OID and CREATE
+        # DATABASE does NOT copy it (a key set in template1 is not carried to its
+        # clones), so without a server default the first encrypted CREATE TABLE in a
+        # newly created database fails "principal key not configured" under a
+        # cluster-wide default_table_access_method = tde_heap. The default key is a
+        # global-provider feature; the file keyring (standalone, database-scoped) has
+        # no server default, so this applies to the vault/kmip providers only. Create
+        # precedes set, and the set is strict like the principal-key set above.
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
+            || echo "pg_tde: create default key returned non-zero (may already exist), continuing to set"
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_default_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
+            || tde_bootstrap_fatal "failed to set default principal key '${TDE_KEY_NAME}-default'"
     fi
 
     # WAL encryption is global-only: the file keyring is a database-scoped

--- a/role_scripts/10/primary/start.sh
+++ b/role_scripts/10/primary/start.sh
@@ -123,8 +123,18 @@ SQL
     # Register the key provider (global preferred; file is standalone only).
     case "${TDE_PROVIDER_KIND:-}" in
         vault)
-            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-                "SELECT pg_tde_add_global_key_provider_vault_v2('${TDE_PROVIDER_NAME}','${TDE_VAULT_ADDR}','${TDE_VAULT_MOUNT}','${TDE_VAULT_TOKEN_PATH}','${TDE_VAULT_CA_PATH}');" || true
+            # pg_tde_add_global_key_provider_vault_v2 has a 5-arg form and a 6-arg
+            # form that also takes a Vault Enterprise namespace. Pass the namespace
+            # (spec.tde.keyProvider.vault.namespace -> TDE_VAULT_NAMESPACE) only when
+            # it is set, so the common namespace-less case keeps the 5-arg form; the
+            # namespace was otherwise accepted in the CRD but silently dropped here.
+            if [[ -n "${TDE_VAULT_NAMESPACE:-}" ]]; then
+                psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                    "SELECT pg_tde_add_global_key_provider_vault_v2('${TDE_PROVIDER_NAME}','${TDE_VAULT_ADDR}','${TDE_VAULT_MOUNT}','${TDE_VAULT_TOKEN_PATH}','${TDE_VAULT_CA_PATH}','${TDE_VAULT_NAMESPACE}');" || true
+            else
+                psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                    "SELECT pg_tde_add_global_key_provider_vault_v2('${TDE_PROVIDER_NAME}','${TDE_VAULT_ADDR}','${TDE_VAULT_MOUNT}','${TDE_VAULT_TOKEN_PATH}','${TDE_VAULT_CA_PATH}');" || true
+            fi
             ;;
         kmip)
             psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \

--- a/role_scripts/10/primary/start.sh
+++ b/role_scripts/10/primary/start.sh
@@ -160,17 +160,22 @@ SQL
         # encryption. pg_tde stores the principal key per database OID and CREATE
         # DATABASE does NOT copy it (a key set in template1 is not carried to its
         # clones), so without a server default the first encrypted CREATE TABLE in a
-        # newly created database fails "principal key not configured" under a
-        # cluster-wide default_table_access_method = tde_heap. The default key is a
-        # global-provider feature; the file keyring (standalone, database-scoped) has
-        # no server default, so this applies to the vault/kmip providers only. Create
-        # precedes set, and the set is strict like the principal-key set above.
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
-            || echo "pg_tde: create default key returned non-zero (may already exist), continuing to set"
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_set_default_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
-            || tde_bootstrap_fatal "failed to set default principal key '${TDE_KEY_NAME}-default'"
+        # newly created database fails "principal key not configured". This only
+        # matters when new tables are encrypted by default or enforced cluster-wide,
+        # so gate it on TDE_DEFAULT_AM/TDE_ENFORCE (mirroring how the WAL block below
+        # gates on TDE_ENCRYPT_WAL): a plain opt-in-per-table cluster does not need a
+        # server default and should not take the strict-set crash-loop risk for it.
+        # The default key is a global-provider feature; the file keyring (standalone,
+        # database-scoped) has no server default, so this applies to vault/kmip only.
+        # Create precedes set, and the set is strict like the principal-key set above.
+        if [[ "${TDE_DEFAULT_AM:-false}" == "true" || "${TDE_ENFORCE:-false}" == "true" ]]; then
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
+                || echo "pg_tde: create default key returned non-zero (may already exist), continuing to set"
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_set_default_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
+                || tde_bootstrap_fatal "failed to set default principal key '${TDE_KEY_NAME}-default'"
+        fi
     fi
 
     # WAL encryption is global-only: the file keyring is a database-scoped

--- a/role_scripts/10/primary/start.sh
+++ b/role_scripts/10/primary/start.sh
@@ -120,9 +120,15 @@ SQL
             ;;
     esac
 
-    # Set the per-database principal key.
-    psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-        "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+    # Set the per-database principal key with the setter that matches the
+    # provider scope: file providers are database-scoped, vault/kmip are global.
+    if [[ "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+    else
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+    fi
 
     # If WAL encryption is requested, set the server key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then

--- a/role_scripts/10/primary/start.sh
+++ b/role_scripts/10/primary/start.sh
@@ -126,14 +126,14 @@ SQL
     # Key setup is strict: a failure fails the bootstrap loudly rather than booting
     # with no principal key, which would silently break encrypted-table creation.
     if [[ "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || { echo "pg_tde FATAL: failed to set database principal key '${TDE_KEY_NAME}'"; exit 1; }
     else
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
@@ -143,7 +143,7 @@ SQL
 
     # If WAL encryption is requested, create + set the server (WAL) key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create WAL server key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \

--- a/role_scripts/10/standby/ha_backup_job.sh
+++ b/role_scripts/10/standby/ha_backup_job.sh
@@ -60,10 +60,12 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     mkdir -p "$PGDATA"
     rm -rf "$PGDATA"/*
     chmod 0700 "$PGDATA"
+    BASEBACKUP=pg_basebackup
+    [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
     if [[ "${SSL:-0}" == "ON" ]]; then
-        pg_basebackup -X fetch --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
+        "$BASEBACKUP" -X fetch --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
     else
-        pg_basebackup -X fetch --no-password --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST"
+        "$BASEBACKUP" -X fetch --no-password --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST"
     fi
 fi
 
@@ -84,7 +86,16 @@ else
   echo "wal_keep_segments = 160" >>/tmp/postgresql.conf
 fi
 
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 echo "max_replication_slots = 90" >>/tmp/postgresql.conf
 echo "wal_log_hints = on" >>/tmp/postgresql.conf
 

--- a/role_scripts/10/standby/ha_backup_job.sh
+++ b/role_scripts/10/standby/ha_backup_job.sh
@@ -95,6 +95,7 @@ echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
     [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
     [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
     echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
 fi
 echo "max_replication_slots = 90" >>/tmp/postgresql.conf

--- a/role_scripts/10/standby/ha_backup_job.sh
+++ b/role_scripts/10/standby/ha_backup_job.sh
@@ -62,6 +62,7 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     chmod 0700 "$PGDATA"
     BASEBACKUP=pg_basebackup
     [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
+    echo "pg_tde: seeding standby with '$BASEBACKUP' (TDE_ENABLED=${TDE_ENABLED:-false})"
     if [[ "${SSL:-0}" == "ON" ]]; then
         "$BASEBACKUP" -X fetch --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
     else

--- a/role_scripts/10/standby/run.sh
+++ b/role_scripts/10/standby/run.sh
@@ -89,7 +89,6 @@ if [[ "$WAL_LIMIT_POLICY" == "ReplicationSlot" ]]; then
   done
 fi
 
-
 if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     if [[ ! -e "/var/pv/IGNORE_FILESYSTEM_MOUNT_CHECK" ]]; then
       # Robust /var/pv mount availability check before any destructive operation or basebackup
@@ -118,10 +117,12 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     mkdir -p "$PGDATA"
     rm -rf "$PGDATA"/*
     chmod 0700 "$PGDATA"
+    BASEBACKUP=pg_basebackup
+    [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
     if [[ "${SSL:-0}" == "ON" ]]; then
-        pg_basebackup -Xs -c fast --pgdata "$PGDATA" --max-rate=1024M --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
+        "$BASEBACKUP" -Xs -c fast --pgdata "$PGDATA" --max-rate=1024M --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
     else
-        pg_basebackup -Xs -c fast --no-password --max-rate=1024M --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST"
+        "$BASEBACKUP" -Xs -c fast --no-password --max-rate=1024M --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST"
     fi
     touch $PGDATA/recovery.conf
 else
@@ -154,7 +155,16 @@ echo "wal_log_hints = on" >>/tmp/postgresql.conf
 
 echo "archive_mode = always" >>/tmp/postgresql.conf
 echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 echo "max_replication_slots = 90" >>/tmp/postgresql.conf
 if [ "$STANDBY" == "hot" ]; then
     echo "hot_standby = on" >>/tmp/postgresql.conf

--- a/role_scripts/10/standby/run.sh
+++ b/role_scripts/10/standby/run.sh
@@ -164,6 +164,7 @@ echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
     [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
     [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
     echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
 fi
 echo "max_replication_slots = 90" >>/tmp/postgresql.conf

--- a/role_scripts/10/standby/run.sh
+++ b/role_scripts/10/standby/run.sh
@@ -119,6 +119,7 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     chmod 0700 "$PGDATA"
     BASEBACKUP=pg_basebackup
     [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
+    echo "pg_tde: seeding standby with '$BASEBACKUP' (TDE_ENABLED=${TDE_ENABLED:-false})"
     if [[ "${SSL:-0}" == "ON" ]]; then
         "$BASEBACKUP" -Xs -c fast --pgdata "$PGDATA" --max-rate=1024M --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
     else

--- a/role_scripts/10/standby/warm_stanby.sh
+++ b/role_scripts/10/standby/warm_stanby.sh
@@ -41,6 +41,7 @@ echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
     [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
     [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
     echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
 fi
 

--- a/role_scripts/10/standby/warm_stanby.sh
+++ b/role_scripts/10/standby/warm_stanby.sh
@@ -33,7 +33,16 @@ echo "wal_log_hints = on" >>/tmp/postgresql.conf
 
 echo "archive_mode = always" >>/tmp/postgresql.conf
 echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 
 echo "hot_standby = off" >>/tmp/postgresql.conf
 

--- a/role_scripts/11/primary/start.sh
+++ b/role_scripts/11/primary/start.sh
@@ -129,20 +129,35 @@ SQL
             ;;
     esac
 
-    # Set the per-database principal key with the setter that matches the
-    # provider scope: file providers are database-scoped, vault/kmip are global.
+    # Create then set the per-database principal key. pg_tde requires the key to
+    # exist before it can be set as principal, so create precedes set. The setter
+    # matches the provider scope (file is database-scoped, vault/kmip are global).
+    # Key setup is strict: a failure fails the bootstrap loudly rather than booting
+    # with no principal key, which would silently break encrypted-table creation.
     if [[ "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+            "SELECT pg_tde_create_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
+            || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
+            || { echo "pg_tde FATAL: failed to set database principal key '${TDE_KEY_NAME}'"; exit 1; }
     else
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+            "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
+            || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
+            || { echo "pg_tde FATAL: failed to set global principal key '${TDE_KEY_NAME}'"; exit 1; }
     fi
 
-    # If WAL encryption is requested, set the server key too (global only).
+    # If WAL encryption is requested, create + set the server (WAL) key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_set_server_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" || true
+            "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
+            || echo "pg_tde: create WAL server key returned non-zero (may already exist), continuing to set"
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_server_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
+            || { echo "pg_tde FATAL: failed to set WAL server key '${TDE_KEY_NAME}-wal'"; exit 1; }
     fi
 fi
 

--- a/role_scripts/11/primary/start.sh
+++ b/role_scripts/11/primary/start.sh
@@ -132,8 +132,18 @@ SQL
     # Register the key provider (global preferred; file is standalone only).
     case "${TDE_PROVIDER_KIND:-}" in
         vault)
-            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-                "SELECT pg_tde_add_global_key_provider_vault_v2('${TDE_PROVIDER_NAME}','${TDE_VAULT_ADDR}','${TDE_VAULT_MOUNT}','${TDE_VAULT_TOKEN_PATH}','${TDE_VAULT_CA_PATH}');" || true
+            # pg_tde_add_global_key_provider_vault_v2 has a 5-arg form and a 6-arg
+            # form that also takes a Vault Enterprise namespace. Pass the namespace
+            # (spec.tde.keyProvider.vault.namespace -> TDE_VAULT_NAMESPACE) only when
+            # it is set, so the common namespace-less case keeps the 5-arg form; the
+            # namespace was otherwise accepted in the CRD but silently dropped here.
+            if [[ -n "${TDE_VAULT_NAMESPACE:-}" ]]; then
+                psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                    "SELECT pg_tde_add_global_key_provider_vault_v2('${TDE_PROVIDER_NAME}','${TDE_VAULT_ADDR}','${TDE_VAULT_MOUNT}','${TDE_VAULT_TOKEN_PATH}','${TDE_VAULT_CA_PATH}','${TDE_VAULT_NAMESPACE}');" || true
+            else
+                psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                    "SELECT pg_tde_add_global_key_provider_vault_v2('${TDE_PROVIDER_NAME}','${TDE_VAULT_ADDR}','${TDE_VAULT_MOUNT}','${TDE_VAULT_TOKEN_PATH}','${TDE_VAULT_CA_PATH}');" || true
+            fi
             ;;
         kmip)
             psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \

--- a/role_scripts/11/primary/start.sh
+++ b/role_scripts/11/primary/start.sh
@@ -109,6 +109,18 @@ if [[ "${TDE_ENABLED:-false}" == "true" && "${BOOTSTRAP}" == "true" ]]; then
     # post-bootstrap config that carries pg_tde.cipher is not loaded yet, so without
     # this the principal key would be created (and validated) at the wrong length.
     export PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}"
+    # tde_bootstrap_fatal aborts a failed first-time TDE bootstrap loudly. This runs
+    # only during initial initialization (BOOTSTRAP=true), so there is no user data
+    # yet; wipe the half-initialized data dir and exit non-zero. That forces a full
+    # re-bootstrap on the next start instead of falling through to a keyless boot
+    # (which would silently disable encryption). The pod crash-loops visibly until
+    # the key provider is reachable.
+    tde_bootstrap_fatal() {
+        echo "pg_tde FATAL: $1"
+        pg_ctl -D "$PGDATA" -m immediate -w stop || true
+        rm -rf "${PGDATA:?}"/* || true
+        exit 1
+    }
     # Enable the extension in the default databases. template1 makes it the
     # default for future databases.
     for TDE_DB in template1 "$POSTGRES_DB"; do
@@ -144,14 +156,14 @@ SQL
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
-            || { echo "pg_tde FATAL: failed to set database principal key '${TDE_KEY_NAME}'"; exit 1; }
+            || tde_bootstrap_fatal "failed to set database principal key '${TDE_KEY_NAME}'"
     else
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
-            || { echo "pg_tde FATAL: failed to set global principal key '${TDE_KEY_NAME}'"; exit 1; }
+            || tde_bootstrap_fatal "failed to set global principal key '${TDE_KEY_NAME}'"
     fi
 
     # If WAL encryption is requested, create + set the server (WAL) key too (global only).
@@ -161,7 +173,7 @@ SQL
             || echo "pg_tde: create WAL server key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_server_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
-            || { echo "pg_tde FATAL: failed to set WAL server key '${TDE_KEY_NAME}-wal'"; exit 1; }
+            || tde_bootstrap_fatal "failed to set WAL server key '${TDE_KEY_NAME}-wal'"
     fi
 fi
 

--- a/role_scripts/11/primary/start.sh
+++ b/role_scripts/11/primary/start.sh
@@ -105,6 +105,10 @@ echo
 # database and superuser exist and before any encrypted table or the
 # default_table_access_method flip can be used. Idempotent on retries.
 if [[ "${TDE_ENABLED:-false}" == "true" && "${BOOTSTRAP}" == "true" ]]; then
+    # Run every pg_tde key operation in this block at the configured cipher. The
+    # post-bootstrap config that carries pg_tde.cipher is not loaded yet, so without
+    # this the principal key would be created (and validated) at the wrong length.
+    export PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}"
     # Enable the extension in the default databases. template1 makes it the
     # default for future databases.
     for TDE_DB in template1 "$POSTGRES_DB"; do
@@ -135,14 +139,14 @@ SQL
     # Key setup is strict: a failure fails the bootstrap loudly rather than booting
     # with no principal key, which would silently break encrypted-table creation.
     if [[ "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
-        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || { echo "pg_tde FATAL: failed to set database principal key '${TDE_KEY_NAME}'"; exit 1; }
     else
-        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
@@ -152,7 +156,7 @@ SQL
 
     # If WAL encryption is requested, create + set the server (WAL) key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
-        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create WAL server key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
@@ -160,6 +164,8 @@ SQL
             || { echo "pg_tde FATAL: failed to set WAL server key '${TDE_KEY_NAME}-wal'"; exit 1; }
     fi
 fi
+
+unset PGOPTIONS
 
 if [[ "$BOOTSTRAP" == "true" ]];then
   # initialize database

--- a/role_scripts/11/primary/start.sh
+++ b/role_scripts/11/primary/start.sh
@@ -164,6 +164,22 @@ SQL
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || tde_bootstrap_fatal "failed to set global principal key '${TDE_KEY_NAME}'"
+
+        # Set a server-wide DEFAULT principal key so databases created later inherit
+        # encryption. pg_tde stores the principal key per database OID and CREATE
+        # DATABASE does NOT copy it (a key set in template1 is not carried to its
+        # clones), so without a server default the first encrypted CREATE TABLE in a
+        # newly created database fails "principal key not configured" under a
+        # cluster-wide default_table_access_method = tde_heap. The default key is a
+        # global-provider feature; the file keyring (standalone, database-scoped) has
+        # no server default, so this applies to the vault/kmip providers only. Create
+        # precedes set, and the set is strict like the principal-key set above.
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
+            || echo "pg_tde: create default key returned non-zero (may already exist), continuing to set"
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_default_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
+            || tde_bootstrap_fatal "failed to set default principal key '${TDE_KEY_NAME}-default'"
     fi
 
     # WAL encryption is global-only: the file keyring is a database-scoped

--- a/role_scripts/11/primary/start.sh
+++ b/role_scripts/11/primary/start.sh
@@ -169,17 +169,22 @@ SQL
         # encryption. pg_tde stores the principal key per database OID and CREATE
         # DATABASE does NOT copy it (a key set in template1 is not carried to its
         # clones), so without a server default the first encrypted CREATE TABLE in a
-        # newly created database fails "principal key not configured" under a
-        # cluster-wide default_table_access_method = tde_heap. The default key is a
-        # global-provider feature; the file keyring (standalone, database-scoped) has
-        # no server default, so this applies to the vault/kmip providers only. Create
-        # precedes set, and the set is strict like the principal-key set above.
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
-            || echo "pg_tde: create default key returned non-zero (may already exist), continuing to set"
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_set_default_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
-            || tde_bootstrap_fatal "failed to set default principal key '${TDE_KEY_NAME}-default'"
+        # newly created database fails "principal key not configured". This only
+        # matters when new tables are encrypted by default or enforced cluster-wide,
+        # so gate it on TDE_DEFAULT_AM/TDE_ENFORCE (mirroring how the WAL block below
+        # gates on TDE_ENCRYPT_WAL): a plain opt-in-per-table cluster does not need a
+        # server default and should not take the strict-set crash-loop risk for it.
+        # The default key is a global-provider feature; the file keyring (standalone,
+        # database-scoped) has no server default, so this applies to vault/kmip only.
+        # Create precedes set, and the set is strict like the principal-key set above.
+        if [[ "${TDE_DEFAULT_AM:-false}" == "true" || "${TDE_ENFORCE:-false}" == "true" ]]; then
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
+                || echo "pg_tde: create default key returned non-zero (may already exist), continuing to set"
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_set_default_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
+                || tde_bootstrap_fatal "failed to set default principal key '${TDE_KEY_NAME}-default'"
+        fi
     fi
 
     # WAL encryption is global-only: the file keyring is a database-scoped

--- a/role_scripts/11/primary/start.sh
+++ b/role_scripts/11/primary/start.sh
@@ -166,6 +166,13 @@ SQL
             || tde_bootstrap_fatal "failed to set global principal key '${TDE_KEY_NAME}'"
     fi
 
+    # WAL encryption is global-only: the file keyring is a database-scoped
+    # provider and cannot back a server key. The operator webhook already rejects
+    # this combination, so this is a fail-closed backstop with a clear message
+    # (instead of a swallowed error that crash-loops on the misleading set-key fatal).
+    if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" && "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
+        tde_bootstrap_fatal "WAL encryption requires a global (vault or kmip) key provider; the file keyring cannot back WAL encryption"
+    fi
     # If WAL encryption is requested, create + set the server (WAL) key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \

--- a/role_scripts/11/primary/start.sh
+++ b/role_scripts/11/primary/start.sh
@@ -135,14 +135,14 @@ SQL
     # Key setup is strict: a failure fails the bootstrap loudly rather than booting
     # with no principal key, which would silently break encrypted-table creation.
     if [[ "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || { echo "pg_tde FATAL: failed to set database principal key '${TDE_KEY_NAME}'"; exit 1; }
     else
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
@@ -152,7 +152,7 @@ SQL
 
     # If WAL encryption is requested, create + set the server (WAL) key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create WAL server key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \

--- a/role_scripts/11/primary/start.sh
+++ b/role_scripts/11/primary/start.sh
@@ -41,7 +41,11 @@ else
     echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
 fi
 
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 
 if [[ "${SSL:-0}" == "ON" ]]; then
     echo "ssl =on" >>/tmp/postgresql.conf
@@ -96,6 +100,45 @@ echo
 
 psql+=(--username "$POSTGRES_USER" --dbname "$POSTGRES_DB")
 echo
+
+# pg_tde principal-key bootstrap. Runs once on first initialization, after the
+# database and superuser exist and before any encrypted table or the
+# default_table_access_method flip can be used. Idempotent on retries.
+if [[ "${TDE_ENABLED:-false}" == "true" && "${BOOTSTRAP}" == "true" ]]; then
+    # Enable the extension in the default databases. template1 makes it the
+    # default for future databases.
+    for TDE_DB in template1 "$POSTGRES_DB"; do
+        psql -U postgres -d "$TDE_DB" -v ON_ERROR_STOP=1 <<SQL
+CREATE EXTENSION IF NOT EXISTS ${TDE_EXTENSION:-pg_tde};
+SQL
+    done
+
+    # Register the key provider (global preferred; file is standalone only).
+    case "${TDE_PROVIDER_KIND:-}" in
+        vault)
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_add_global_key_provider_vault_v2('${TDE_PROVIDER_NAME}','${TDE_VAULT_ADDR}','${TDE_VAULT_MOUNT}','${TDE_VAULT_TOKEN_PATH}','${TDE_VAULT_CA_PATH}');" || true
+            ;;
+        kmip)
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_add_global_key_provider_kmip('${TDE_PROVIDER_NAME}','${TDE_KMIP_ADDR}',${TDE_KMIP_PORT},'${TDE_KMIP_CLIENT_CERT_PATH}','${TDE_KMIP_CLIENT_KEY_PATH}','${TDE_KMIP_CA_PATH}');" || true
+            ;;
+        file)
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_add_database_key_provider_file('${TDE_PROVIDER_NAME}','${TDE_FILE_PATH}');" || true
+            ;;
+    esac
+
+    # Set the per-database principal key.
+    psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+
+    # If WAL encryption is requested, set the server key too (global only).
+    if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_server_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" || true
+    fi
+fi
 
 if [[ "$BOOTSTRAP" == "true" ]];then
   # initialize database
@@ -213,6 +256,14 @@ fi
 mv /tmp/pg_hba.conf "$PGDATA/pg_hba.conf"
 
 touch /tmp/postgresql.conf
+# pg_tde runtime GUCs. Authored in the post-bootstrap rewrite, after the
+# extension and principal key exist, so default_table_access_method is safe.
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 if [ "$STANDBY" == "hot" ]; then
     echo "hot_standby = on" >>/tmp/postgresql.conf
 else
@@ -253,4 +304,3 @@ if [[ "$STREAMING" == "synchronous" ]]; then
 fi
 # ref: https://superuser.com/a/246841/985093
 cat /tmp/postgresql.conf $PGDATA/postgresql.conf >"/tmp/postgresql.conf.tmp" && mv "/tmp/postgresql.conf.tmp" "$PGDATA/postgresql.conf"
-

--- a/role_scripts/11/primary/start.sh
+++ b/role_scripts/11/primary/start.sh
@@ -129,9 +129,15 @@ SQL
             ;;
     esac
 
-    # Set the per-database principal key.
-    psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-        "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+    # Set the per-database principal key with the setter that matches the
+    # provider scope: file providers are database-scoped, vault/kmip are global.
+    if [[ "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+    else
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+    fi
 
     # If WAL encryption is requested, set the server key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then

--- a/role_scripts/11/standby/ha_backup_job.sh
+++ b/role_scripts/11/standby/ha_backup_job.sh
@@ -99,6 +99,7 @@ echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
     [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
     [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
     echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
 fi
 

--- a/role_scripts/11/standby/ha_backup_job.sh
+++ b/role_scripts/11/standby/ha_backup_job.sh
@@ -60,10 +60,12 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     mkdir -p "$PGDATA"
     rm -rf "$PGDATA"/*
     chmod 0700 "$PGDATA"
+    BASEBACKUP=pg_basebackup
+    [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
     if [[ "${SSL:-0}" == "ON" ]]; then
-        pg_basebackup -X fetch --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
+        "$BASEBACKUP" -X fetch --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
     else
-        pg_basebackup -X fetch --no-password --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST"
+        "$BASEBACKUP" -X fetch --no-password --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST"
     fi
 fi
 
@@ -88,7 +90,16 @@ echo "wal_log_hints = on" >>/tmp/postgresql.conf
 
 echo "archive_mode = always" >>/tmp/postgresql.conf
 echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 
 if [ "$STANDBY" == "hot" ]; then
     echo "hot_standby = on" >>/tmp/postgresql.conf

--- a/role_scripts/11/standby/ha_backup_job.sh
+++ b/role_scripts/11/standby/ha_backup_job.sh
@@ -62,6 +62,7 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     chmod 0700 "$PGDATA"
     BASEBACKUP=pg_basebackup
     [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
+    echo "pg_tde: seeding standby with '$BASEBACKUP' (TDE_ENABLED=${TDE_ENABLED:-false})"
     if [[ "${SSL:-0}" == "ON" ]]; then
         "$BASEBACKUP" -X fetch --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
     else

--- a/role_scripts/11/standby/run.sh
+++ b/role_scripts/11/standby/run.sh
@@ -168,6 +168,7 @@ echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
     [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
     [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
     echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
 fi
 

--- a/role_scripts/11/standby/run.sh
+++ b/role_scripts/11/standby/run.sh
@@ -116,10 +116,12 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     mkdir -p "$PGDATA"
     rm -rf "$PGDATA"/*
     chmod 0700 "$PGDATA"
+    BASEBACKUP=pg_basebackup
+    [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
     if [[ "${SSL:-0}" == "ON" ]]; then
-        pg_basebackup -Xs -c fast --pgdata "$PGDATA" --max-rate=1024M --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
+        "$BASEBACKUP" -Xs -c fast --pgdata "$PGDATA" --max-rate=1024M --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
     else
-        pg_basebackup -Xs -c fast --no-password --max-rate=1024M --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST"
+        "$BASEBACKUP" -Xs -c fast --no-password --max-rate=1024M --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST"
     fi
     touch /var/pv/data/standby.signal
 else
@@ -157,7 +159,16 @@ else
     echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
 fi
 
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 
 if [ "$STANDBY" == "hot" ]; then
     echo "hot_standby = on" >>/tmp/postgresql.conf

--- a/role_scripts/11/standby/run.sh
+++ b/role_scripts/11/standby/run.sh
@@ -118,6 +118,7 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     chmod 0700 "$PGDATA"
     BASEBACKUP=pg_basebackup
     [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
+    echo "pg_tde: seeding standby with '$BASEBACKUP' (TDE_ENABLED=${TDE_ENABLED:-false})"
     if [[ "${SSL:-0}" == "ON" ]]; then
         "$BASEBACKUP" -Xs -c fast --pgdata "$PGDATA" --max-rate=1024M --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
     else

--- a/role_scripts/11/standby/warm_stanby.sh
+++ b/role_scripts/11/standby/warm_stanby.sh
@@ -43,6 +43,7 @@ echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
     [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
     [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
     echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
 fi
 

--- a/role_scripts/11/standby/warm_stanby.sh
+++ b/role_scripts/11/standby/warm_stanby.sh
@@ -35,7 +35,16 @@ echo "archive_mode = always" >>/tmp/postgresql.conf
 echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
 
 echo "hot_standby = off" >>/tmp/postgresql.conf
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 
 if [[ "$STREAMING" == "synchronous" ]]; then
     # setup synchronous streaming replication

--- a/role_scripts/12/primary/start.sh
+++ b/role_scripts/12/primary/start.sh
@@ -149,9 +149,15 @@ SQL
             ;;
     esac
 
-    # Set the per-database principal key.
-    psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-        "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+    # Set the per-database principal key with the setter that matches the
+    # provider scope: file providers are database-scoped, vault/kmip are global.
+    if [[ "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+    else
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+    fi
 
     # If WAL encryption is requested, set the server key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then

--- a/role_scripts/12/primary/start.sh
+++ b/role_scripts/12/primary/start.sh
@@ -155,14 +155,14 @@ SQL
     # Key setup is strict: a failure fails the bootstrap loudly rather than booting
     # with no principal key, which would silently break encrypted-table creation.
     if [[ "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || { echo "pg_tde FATAL: failed to set database principal key '${TDE_KEY_NAME}'"; exit 1; }
     else
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
@@ -172,7 +172,7 @@ SQL
 
     # If WAL encryption is requested, create + set the server (WAL) key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create WAL server key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \

--- a/role_scripts/12/primary/start.sh
+++ b/role_scripts/12/primary/start.sh
@@ -149,20 +149,35 @@ SQL
             ;;
     esac
 
-    # Set the per-database principal key with the setter that matches the
-    # provider scope: file providers are database-scoped, vault/kmip are global.
+    # Create then set the per-database principal key. pg_tde requires the key to
+    # exist before it can be set as principal, so create precedes set. The setter
+    # matches the provider scope (file is database-scoped, vault/kmip are global).
+    # Key setup is strict: a failure fails the bootstrap loudly rather than booting
+    # with no principal key, which would silently break encrypted-table creation.
     if [[ "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+            "SELECT pg_tde_create_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
+            || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
+            || { echo "pg_tde FATAL: failed to set database principal key '${TDE_KEY_NAME}'"; exit 1; }
     else
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+            "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
+            || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
+            || { echo "pg_tde FATAL: failed to set global principal key '${TDE_KEY_NAME}'"; exit 1; }
     fi
 
-    # If WAL encryption is requested, set the server key too (global only).
+    # If WAL encryption is requested, create + set the server (WAL) key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_set_server_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" || true
+            "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
+            || echo "pg_tde: create WAL server key returned non-zero (may already exist), continuing to set"
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_server_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
+            || { echo "pg_tde FATAL: failed to set WAL server key '${TDE_KEY_NAME}-wal'"; exit 1; }
     fi
 fi
 

--- a/role_scripts/12/primary/start.sh
+++ b/role_scripts/12/primary/start.sh
@@ -184,6 +184,22 @@ SQL
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || tde_bootstrap_fatal "failed to set global principal key '${TDE_KEY_NAME}'"
+
+        # Set a server-wide DEFAULT principal key so databases created later inherit
+        # encryption. pg_tde stores the principal key per database OID and CREATE
+        # DATABASE does NOT copy it (a key set in template1 is not carried to its
+        # clones), so without a server default the first encrypted CREATE TABLE in a
+        # newly created database fails "principal key not configured" under a
+        # cluster-wide default_table_access_method = tde_heap. The default key is a
+        # global-provider feature; the file keyring (standalone, database-scoped) has
+        # no server default, so this applies to the vault/kmip providers only. Create
+        # precedes set, and the set is strict like the principal-key set above.
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
+            || echo "pg_tde: create default key returned non-zero (may already exist), continuing to set"
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_default_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
+            || tde_bootstrap_fatal "failed to set default principal key '${TDE_KEY_NAME}-default'"
     fi
 
     # WAL encryption is global-only: the file keyring is a database-scoped

--- a/role_scripts/12/primary/start.sh
+++ b/role_scripts/12/primary/start.sh
@@ -42,7 +42,11 @@ else
     echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
 fi
 
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 
 if [[ "${SSL:-0}" == "ON" ]]; then
     echo "ssl =on" >>/tmp/postgresql.conf
@@ -116,6 +120,45 @@ echo
 
 psql+=(--username "$POSTGRES_USER" --dbname "$POSTGRES_DB")
 echo
+
+# pg_tde principal-key bootstrap. Runs once on first initialization, after the
+# database and superuser exist and before any encrypted table or the
+# default_table_access_method flip can be used. Idempotent on retries.
+if [[ "${TDE_ENABLED:-false}" == "true" && "${BOOTSTRAP}" == "true" ]]; then
+    # Enable the extension in the default databases. template1 makes it the
+    # default for future databases.
+    for TDE_DB in template1 "$POSTGRES_DB"; do
+        psql -U postgres -d "$TDE_DB" -v ON_ERROR_STOP=1 <<SQL
+CREATE EXTENSION IF NOT EXISTS ${TDE_EXTENSION:-pg_tde};
+SQL
+    done
+
+    # Register the key provider (global preferred; file is standalone only).
+    case "${TDE_PROVIDER_KIND:-}" in
+        vault)
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_add_global_key_provider_vault_v2('${TDE_PROVIDER_NAME}','${TDE_VAULT_ADDR}','${TDE_VAULT_MOUNT}','${TDE_VAULT_TOKEN_PATH}','${TDE_VAULT_CA_PATH}');" || true
+            ;;
+        kmip)
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_add_global_key_provider_kmip('${TDE_PROVIDER_NAME}','${TDE_KMIP_ADDR}',${TDE_KMIP_PORT},'${TDE_KMIP_CLIENT_CERT_PATH}','${TDE_KMIP_CLIENT_KEY_PATH}','${TDE_KMIP_CA_PATH}');" || true
+            ;;
+        file)
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_add_database_key_provider_file('${TDE_PROVIDER_NAME}','${TDE_FILE_PATH}');" || true
+            ;;
+    esac
+
+    # Set the per-database principal key.
+    psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+
+    # If WAL encryption is requested, set the server key too (global only).
+    if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_server_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" || true
+    fi
+fi
 
 if [[ "$BOOTSTRAP" == "true" ]];then
   # initialize database
@@ -233,6 +276,14 @@ fi
 mv /tmp/pg_hba.conf "$PGDATA/pg_hba.conf"
 
 touch /tmp/postgresql.conf
+# pg_tde runtime GUCs. Authored in the post-bootstrap rewrite, after the
+# extension and principal key exist, so default_table_access_method is safe.
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 if [ "$STANDBY" == "hot" ]; then
     echo "hot_standby = on" >>/tmp/postgresql.conf
 else

--- a/role_scripts/12/primary/start.sh
+++ b/role_scripts/12/primary/start.sh
@@ -125,6 +125,10 @@ echo
 # database and superuser exist and before any encrypted table or the
 # default_table_access_method flip can be used. Idempotent on retries.
 if [[ "${TDE_ENABLED:-false}" == "true" && "${BOOTSTRAP}" == "true" ]]; then
+    # Run every pg_tde key operation in this block at the configured cipher. The
+    # post-bootstrap config that carries pg_tde.cipher is not loaded yet, so without
+    # this the principal key would be created (and validated) at the wrong length.
+    export PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}"
     # Enable the extension in the default databases. template1 makes it the
     # default for future databases.
     for TDE_DB in template1 "$POSTGRES_DB"; do
@@ -155,14 +159,14 @@ SQL
     # Key setup is strict: a failure fails the bootstrap loudly rather than booting
     # with no principal key, which would silently break encrypted-table creation.
     if [[ "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
-        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || { echo "pg_tde FATAL: failed to set database principal key '${TDE_KEY_NAME}'"; exit 1; }
     else
-        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
@@ -172,7 +176,7 @@ SQL
 
     # If WAL encryption is requested, create + set the server (WAL) key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
-        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create WAL server key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
@@ -180,6 +184,8 @@ SQL
             || { echo "pg_tde FATAL: failed to set WAL server key '${TDE_KEY_NAME}-wal'"; exit 1; }
     fi
 fi
+
+unset PGOPTIONS
 
 if [[ "$BOOTSTRAP" == "true" ]];then
   # initialize database

--- a/role_scripts/12/primary/start.sh
+++ b/role_scripts/12/primary/start.sh
@@ -189,17 +189,22 @@ SQL
         # encryption. pg_tde stores the principal key per database OID and CREATE
         # DATABASE does NOT copy it (a key set in template1 is not carried to its
         # clones), so without a server default the first encrypted CREATE TABLE in a
-        # newly created database fails "principal key not configured" under a
-        # cluster-wide default_table_access_method = tde_heap. The default key is a
-        # global-provider feature; the file keyring (standalone, database-scoped) has
-        # no server default, so this applies to the vault/kmip providers only. Create
-        # precedes set, and the set is strict like the principal-key set above.
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
-            || echo "pg_tde: create default key returned non-zero (may already exist), continuing to set"
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_set_default_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
-            || tde_bootstrap_fatal "failed to set default principal key '${TDE_KEY_NAME}-default'"
+        # newly created database fails "principal key not configured". This only
+        # matters when new tables are encrypted by default or enforced cluster-wide,
+        # so gate it on TDE_DEFAULT_AM/TDE_ENFORCE (mirroring how the WAL block below
+        # gates on TDE_ENCRYPT_WAL): a plain opt-in-per-table cluster does not need a
+        # server default and should not take the strict-set crash-loop risk for it.
+        # The default key is a global-provider feature; the file keyring (standalone,
+        # database-scoped) has no server default, so this applies to vault/kmip only.
+        # Create precedes set, and the set is strict like the principal-key set above.
+        if [[ "${TDE_DEFAULT_AM:-false}" == "true" || "${TDE_ENFORCE:-false}" == "true" ]]; then
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
+                || echo "pg_tde: create default key returned non-zero (may already exist), continuing to set"
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_set_default_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
+                || tde_bootstrap_fatal "failed to set default principal key '${TDE_KEY_NAME}-default'"
+        fi
     fi
 
     # WAL encryption is global-only: the file keyring is a database-scoped

--- a/role_scripts/12/primary/start.sh
+++ b/role_scripts/12/primary/start.sh
@@ -129,6 +129,18 @@ if [[ "${TDE_ENABLED:-false}" == "true" && "${BOOTSTRAP}" == "true" ]]; then
     # post-bootstrap config that carries pg_tde.cipher is not loaded yet, so without
     # this the principal key would be created (and validated) at the wrong length.
     export PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}"
+    # tde_bootstrap_fatal aborts a failed first-time TDE bootstrap loudly. This runs
+    # only during initial initialization (BOOTSTRAP=true), so there is no user data
+    # yet; wipe the half-initialized data dir and exit non-zero. That forces a full
+    # re-bootstrap on the next start instead of falling through to a keyless boot
+    # (which would silently disable encryption). The pod crash-loops visibly until
+    # the key provider is reachable.
+    tde_bootstrap_fatal() {
+        echo "pg_tde FATAL: $1"
+        pg_ctl -D "$PGDATA" -m immediate -w stop || true
+        rm -rf "${PGDATA:?}"/* || true
+        exit 1
+    }
     # Enable the extension in the default databases. template1 makes it the
     # default for future databases.
     for TDE_DB in template1 "$POSTGRES_DB"; do
@@ -164,14 +176,14 @@ SQL
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
-            || { echo "pg_tde FATAL: failed to set database principal key '${TDE_KEY_NAME}'"; exit 1; }
+            || tde_bootstrap_fatal "failed to set database principal key '${TDE_KEY_NAME}'"
     else
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
-            || { echo "pg_tde FATAL: failed to set global principal key '${TDE_KEY_NAME}'"; exit 1; }
+            || tde_bootstrap_fatal "failed to set global principal key '${TDE_KEY_NAME}'"
     fi
 
     # If WAL encryption is requested, create + set the server (WAL) key too (global only).
@@ -181,7 +193,7 @@ SQL
             || echo "pg_tde: create WAL server key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_server_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
-            || { echo "pg_tde FATAL: failed to set WAL server key '${TDE_KEY_NAME}-wal'"; exit 1; }
+            || tde_bootstrap_fatal "failed to set WAL server key '${TDE_KEY_NAME}-wal'"
     fi
 fi
 

--- a/role_scripts/12/primary/start.sh
+++ b/role_scripts/12/primary/start.sh
@@ -186,6 +186,13 @@ SQL
             || tde_bootstrap_fatal "failed to set global principal key '${TDE_KEY_NAME}'"
     fi
 
+    # WAL encryption is global-only: the file keyring is a database-scoped
+    # provider and cannot back a server key. The operator webhook already rejects
+    # this combination, so this is a fail-closed backstop with a clear message
+    # (instead of a swallowed error that crash-loops on the misleading set-key fatal).
+    if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" && "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
+        tde_bootstrap_fatal "WAL encryption requires a global (vault or kmip) key provider; the file keyring cannot back WAL encryption"
+    fi
     # If WAL encryption is requested, create + set the server (WAL) key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \

--- a/role_scripts/12/primary/start.sh
+++ b/role_scripts/12/primary/start.sh
@@ -152,8 +152,18 @@ SQL
     # Register the key provider (global preferred; file is standalone only).
     case "${TDE_PROVIDER_KIND:-}" in
         vault)
-            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-                "SELECT pg_tde_add_global_key_provider_vault_v2('${TDE_PROVIDER_NAME}','${TDE_VAULT_ADDR}','${TDE_VAULT_MOUNT}','${TDE_VAULT_TOKEN_PATH}','${TDE_VAULT_CA_PATH}');" || true
+            # pg_tde_add_global_key_provider_vault_v2 has a 5-arg form and a 6-arg
+            # form that also takes a Vault Enterprise namespace. Pass the namespace
+            # (spec.tde.keyProvider.vault.namespace -> TDE_VAULT_NAMESPACE) only when
+            # it is set, so the common namespace-less case keeps the 5-arg form; the
+            # namespace was otherwise accepted in the CRD but silently dropped here.
+            if [[ -n "${TDE_VAULT_NAMESPACE:-}" ]]; then
+                psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                    "SELECT pg_tde_add_global_key_provider_vault_v2('${TDE_PROVIDER_NAME}','${TDE_VAULT_ADDR}','${TDE_VAULT_MOUNT}','${TDE_VAULT_TOKEN_PATH}','${TDE_VAULT_CA_PATH}','${TDE_VAULT_NAMESPACE}');" || true
+            else
+                psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                    "SELECT pg_tde_add_global_key_provider_vault_v2('${TDE_PROVIDER_NAME}','${TDE_VAULT_ADDR}','${TDE_VAULT_MOUNT}','${TDE_VAULT_TOKEN_PATH}','${TDE_VAULT_CA_PATH}');" || true
+            fi
             ;;
         kmip)
             psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \

--- a/role_scripts/12/standby/ha_backup_job.sh
+++ b/role_scripts/12/standby/ha_backup_job.sh
@@ -59,10 +59,12 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     mkdir -p "$PGDATA"
     rm -rf "$PGDATA"/*
     chmod 0700 "$PGDATA"
+    BASEBACKUP=pg_basebackup
+    [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
     if [[ "${SSL:-0}" == "ON" ]]; then
-        pg_basebackup -X fetch --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
+        "$BASEBACKUP" -X fetch --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
     else
-        pg_basebackup -X fetch --no-password --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST"
+        "$BASEBACKUP" -X fetch --no-password --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST"
     fi
 fi
 
@@ -89,7 +91,16 @@ echo "wal_log_hints = on" >>/tmp/postgresql.conf
 # we are not doing any archiving by default but it's better to have this config in our postgresql.conf file in case of customization.
 echo "archive_mode = always" >>/tmp/postgresql.conf
 echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 
 if [ "$STANDBY" == "hot" ]; then
     echo "hot_standby = on" >>/tmp/postgresql.conf

--- a/role_scripts/12/standby/ha_backup_job.sh
+++ b/role_scripts/12/standby/ha_backup_job.sh
@@ -61,6 +61,7 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     chmod 0700 "$PGDATA"
     BASEBACKUP=pg_basebackup
     [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
+    echo "pg_tde: seeding standby with '$BASEBACKUP' (TDE_ENABLED=${TDE_ENABLED:-false})"
     if [[ "${SSL:-0}" == "ON" ]]; then
         "$BASEBACKUP" -X fetch --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
     else

--- a/role_scripts/12/standby/ha_backup_job.sh
+++ b/role_scripts/12/standby/ha_backup_job.sh
@@ -100,6 +100,7 @@ echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
     [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
     [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
     echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
 fi
 

--- a/role_scripts/12/standby/run.sh
+++ b/role_scripts/12/standby/run.sh
@@ -89,7 +89,6 @@ if [[ "$WAL_LIMIT_POLICY" == "ReplicationSlot" ]]; then
   done
 fi
 
-
 if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     if [[ ! -e "/var/pv/IGNORE_FILESYSTEM_MOUNT_CHECK" ]]; then
       # Robust /var/pv mount availability check before any destructive operation or basebackup
@@ -117,10 +116,12 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     mkdir -p "$PGDATA"
     rm -rf "$PGDATA"/*
     chmod 0700 "$PGDATA"
+    BASEBACKUP=pg_basebackup
+    [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
     if [[ "${SSL:-0}" == "ON" ]]; then
-        pg_basebackup -Xs -c fast --pgdata "$PGDATA" --max-rate=1024M --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
+        "$BASEBACKUP" -Xs -c fast --pgdata "$PGDATA" --max-rate=1024M --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
     else
-        pg_basebackup -Xs -c fast --no-password --max-rate=1024M --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST"
+        "$BASEBACKUP" -Xs -c fast --no-password --max-rate=1024M --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST"
     fi
     touch /var/pv/data/standby.signal
 else
@@ -150,13 +151,21 @@ if [[ "$WAL_LIMIT_POLICY" == "ReplicationSlot" ]]; then
   echo "primary_slot_name = "$CLEAN_HOSTNAME"" >>/tmp/postgresql.conf
 fi
 
-
 echo "wal_log_hints = on" >>/tmp/postgresql.conf
 
 # we are not doing any archiving by default but it's better to have this config in our postgresql.conf file in case of customization.
 echo "archive_mode = always" >>/tmp/postgresql.conf
 echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 
 if [ "$STANDBY" == "hot" ]; then
     echo "hot_standby = on" >>/tmp/postgresql.conf

--- a/role_scripts/12/standby/run.sh
+++ b/role_scripts/12/standby/run.sh
@@ -118,6 +118,7 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     chmod 0700 "$PGDATA"
     BASEBACKUP=pg_basebackup
     [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
+    echo "pg_tde: seeding standby with '$BASEBACKUP' (TDE_ENABLED=${TDE_ENABLED:-false})"
     if [[ "${SSL:-0}" == "ON" ]]; then
         "$BASEBACKUP" -Xs -c fast --pgdata "$PGDATA" --max-rate=1024M --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
     else

--- a/role_scripts/12/standby/run.sh
+++ b/role_scripts/12/standby/run.sh
@@ -165,6 +165,7 @@ echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
     [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
     [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
     echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
 fi
 

--- a/role_scripts/12/standby/warm_stanby.sh
+++ b/role_scripts/12/standby/warm_stanby.sh
@@ -50,6 +50,7 @@ echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
     [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
     [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
     echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
 fi
 

--- a/role_scripts/12/standby/warm_stanby.sh
+++ b/role_scripts/12/standby/warm_stanby.sh
@@ -42,7 +42,16 @@ else
     echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
 fi
 
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 
 echo "hot_standby = off" >>/tmp/postgresql.conf
 

--- a/role_scripts/13/primary/start.sh
+++ b/role_scripts/13/primary/start.sh
@@ -42,7 +42,11 @@ else
     echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
 fi
 
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 
 if [[ "${SSL:-0}" == "ON" ]]; then
     echo "ssl =on" >>/tmp/postgresql.conf
@@ -137,6 +141,45 @@ echo
 
 psql+=(--username "$POSTGRES_USER" --dbname "$POSTGRES_DB")
 echo
+
+# pg_tde principal-key bootstrap. Runs once on first initialization, after the
+# database and superuser exist and before any encrypted table or the
+# default_table_access_method flip can be used. Idempotent on retries.
+if [[ "${TDE_ENABLED:-false}" == "true" && "${BOOTSTRAP}" == "true" ]]; then
+    # Enable the extension in the default databases. template1 makes it the
+    # default for future databases.
+    for TDE_DB in template1 "$POSTGRES_DB"; do
+        psql -U postgres -d "$TDE_DB" -v ON_ERROR_STOP=1 <<SQL
+CREATE EXTENSION IF NOT EXISTS ${TDE_EXTENSION:-pg_tde};
+SQL
+    done
+
+    # Register the key provider (global preferred; file is standalone only).
+    case "${TDE_PROVIDER_KIND:-}" in
+        vault)
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_add_global_key_provider_vault_v2('${TDE_PROVIDER_NAME}','${TDE_VAULT_ADDR}','${TDE_VAULT_MOUNT}','${TDE_VAULT_TOKEN_PATH}','${TDE_VAULT_CA_PATH}');" || true
+            ;;
+        kmip)
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_add_global_key_provider_kmip('${TDE_PROVIDER_NAME}','${TDE_KMIP_ADDR}',${TDE_KMIP_PORT},'${TDE_KMIP_CLIENT_CERT_PATH}','${TDE_KMIP_CLIENT_KEY_PATH}','${TDE_KMIP_CA_PATH}');" || true
+            ;;
+        file)
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_add_database_key_provider_file('${TDE_PROVIDER_NAME}','${TDE_FILE_PATH}');" || true
+            ;;
+    esac
+
+    # Set the per-database principal key.
+    psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+
+    # If WAL encryption is requested, set the server key too (global only).
+    if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_server_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" || true
+    fi
+fi
 
 if [[ "$BOOTSTRAP" == "true" ]];then
   # initialize database
@@ -264,6 +307,14 @@ fi
 mv /tmp/pg_hba.conf "$PGDATA/pg_hba.conf"
 
 touch /tmp/postgresql.conf
+# pg_tde runtime GUCs. Authored in the post-bootstrap rewrite, after the
+# extension and principal key exist, so default_table_access_method is safe.
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 if [ "$STANDBY" == "hot" ]; then
     echo "hot_standby = on" >>/tmp/postgresql.conf
 else

--- a/role_scripts/13/primary/start.sh
+++ b/role_scripts/13/primary/start.sh
@@ -170,20 +170,35 @@ SQL
             ;;
     esac
 
-    # Set the per-database principal key with the setter that matches the
-    # provider scope: file providers are database-scoped, vault/kmip are global.
+    # Create then set the per-database principal key. pg_tde requires the key to
+    # exist before it can be set as principal, so create precedes set. The setter
+    # matches the provider scope (file is database-scoped, vault/kmip are global).
+    # Key setup is strict: a failure fails the bootstrap loudly rather than booting
+    # with no principal key, which would silently break encrypted-table creation.
     if [[ "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+            "SELECT pg_tde_create_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
+            || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
+            || { echo "pg_tde FATAL: failed to set database principal key '${TDE_KEY_NAME}'"; exit 1; }
     else
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+            "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
+            || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
+            || { echo "pg_tde FATAL: failed to set global principal key '${TDE_KEY_NAME}'"; exit 1; }
     fi
 
-    # If WAL encryption is requested, set the server key too (global only).
+    # If WAL encryption is requested, create + set the server (WAL) key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_set_server_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" || true
+            "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
+            || echo "pg_tde: create WAL server key returned non-zero (may already exist), continuing to set"
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_server_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
+            || { echo "pg_tde FATAL: failed to set WAL server key '${TDE_KEY_NAME}-wal'"; exit 1; }
     fi
 fi
 

--- a/role_scripts/13/primary/start.sh
+++ b/role_scripts/13/primary/start.sh
@@ -146,6 +146,10 @@ echo
 # database and superuser exist and before any encrypted table or the
 # default_table_access_method flip can be used. Idempotent on retries.
 if [[ "${TDE_ENABLED:-false}" == "true" && "${BOOTSTRAP}" == "true" ]]; then
+    # Run every pg_tde key operation in this block at the configured cipher. The
+    # post-bootstrap config that carries pg_tde.cipher is not loaded yet, so without
+    # this the principal key would be created (and validated) at the wrong length.
+    export PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}"
     # Enable the extension in the default databases. template1 makes it the
     # default for future databases.
     for TDE_DB in template1 "$POSTGRES_DB"; do
@@ -176,14 +180,14 @@ SQL
     # Key setup is strict: a failure fails the bootstrap loudly rather than booting
     # with no principal key, which would silently break encrypted-table creation.
     if [[ "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
-        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || { echo "pg_tde FATAL: failed to set database principal key '${TDE_KEY_NAME}'"; exit 1; }
     else
-        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
@@ -193,7 +197,7 @@ SQL
 
     # If WAL encryption is requested, create + set the server (WAL) key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
-        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create WAL server key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
@@ -201,6 +205,8 @@ SQL
             || { echo "pg_tde FATAL: failed to set WAL server key '${TDE_KEY_NAME}-wal'"; exit 1; }
     fi
 fi
+
+unset PGOPTIONS
 
 if [[ "$BOOTSTRAP" == "true" ]];then
   # initialize database

--- a/role_scripts/13/primary/start.sh
+++ b/role_scripts/13/primary/start.sh
@@ -205,6 +205,22 @@ SQL
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || tde_bootstrap_fatal "failed to set global principal key '${TDE_KEY_NAME}'"
+
+        # Set a server-wide DEFAULT principal key so databases created later inherit
+        # encryption. pg_tde stores the principal key per database OID and CREATE
+        # DATABASE does NOT copy it (a key set in template1 is not carried to its
+        # clones), so without a server default the first encrypted CREATE TABLE in a
+        # newly created database fails "principal key not configured" under a
+        # cluster-wide default_table_access_method = tde_heap. The default key is a
+        # global-provider feature; the file keyring (standalone, database-scoped) has
+        # no server default, so this applies to the vault/kmip providers only. Create
+        # precedes set, and the set is strict like the principal-key set above.
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
+            || echo "pg_tde: create default key returned non-zero (may already exist), continuing to set"
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_default_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
+            || tde_bootstrap_fatal "failed to set default principal key '${TDE_KEY_NAME}-default'"
     fi
 
     # WAL encryption is global-only: the file keyring is a database-scoped

--- a/role_scripts/13/primary/start.sh
+++ b/role_scripts/13/primary/start.sh
@@ -176,14 +176,14 @@ SQL
     # Key setup is strict: a failure fails the bootstrap loudly rather than booting
     # with no principal key, which would silently break encrypted-table creation.
     if [[ "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || { echo "pg_tde FATAL: failed to set database principal key '${TDE_KEY_NAME}'"; exit 1; }
     else
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
@@ -193,7 +193,7 @@ SQL
 
     # If WAL encryption is requested, create + set the server (WAL) key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create WAL server key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \

--- a/role_scripts/13/primary/start.sh
+++ b/role_scripts/13/primary/start.sh
@@ -207,6 +207,13 @@ SQL
             || tde_bootstrap_fatal "failed to set global principal key '${TDE_KEY_NAME}'"
     fi
 
+    # WAL encryption is global-only: the file keyring is a database-scoped
+    # provider and cannot back a server key. The operator webhook already rejects
+    # this combination, so this is a fail-closed backstop with a clear message
+    # (instead of a swallowed error that crash-loops on the misleading set-key fatal).
+    if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" && "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
+        tde_bootstrap_fatal "WAL encryption requires a global (vault or kmip) key provider; the file keyring cannot back WAL encryption"
+    fi
     # If WAL encryption is requested, create + set the server (WAL) key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \

--- a/role_scripts/13/primary/start.sh
+++ b/role_scripts/13/primary/start.sh
@@ -210,17 +210,22 @@ SQL
         # encryption. pg_tde stores the principal key per database OID and CREATE
         # DATABASE does NOT copy it (a key set in template1 is not carried to its
         # clones), so without a server default the first encrypted CREATE TABLE in a
-        # newly created database fails "principal key not configured" under a
-        # cluster-wide default_table_access_method = tde_heap. The default key is a
-        # global-provider feature; the file keyring (standalone, database-scoped) has
-        # no server default, so this applies to the vault/kmip providers only. Create
-        # precedes set, and the set is strict like the principal-key set above.
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
-            || echo "pg_tde: create default key returned non-zero (may already exist), continuing to set"
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_set_default_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
-            || tde_bootstrap_fatal "failed to set default principal key '${TDE_KEY_NAME}-default'"
+        # newly created database fails "principal key not configured". This only
+        # matters when new tables are encrypted by default or enforced cluster-wide,
+        # so gate it on TDE_DEFAULT_AM/TDE_ENFORCE (mirroring how the WAL block below
+        # gates on TDE_ENCRYPT_WAL): a plain opt-in-per-table cluster does not need a
+        # server default and should not take the strict-set crash-loop risk for it.
+        # The default key is a global-provider feature; the file keyring (standalone,
+        # database-scoped) has no server default, so this applies to vault/kmip only.
+        # Create precedes set, and the set is strict like the principal-key set above.
+        if [[ "${TDE_DEFAULT_AM:-false}" == "true" || "${TDE_ENFORCE:-false}" == "true" ]]; then
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
+                || echo "pg_tde: create default key returned non-zero (may already exist), continuing to set"
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_set_default_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
+                || tde_bootstrap_fatal "failed to set default principal key '${TDE_KEY_NAME}-default'"
+        fi
     fi
 
     # WAL encryption is global-only: the file keyring is a database-scoped

--- a/role_scripts/13/primary/start.sh
+++ b/role_scripts/13/primary/start.sh
@@ -150,6 +150,18 @@ if [[ "${TDE_ENABLED:-false}" == "true" && "${BOOTSTRAP}" == "true" ]]; then
     # post-bootstrap config that carries pg_tde.cipher is not loaded yet, so without
     # this the principal key would be created (and validated) at the wrong length.
     export PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}"
+    # tde_bootstrap_fatal aborts a failed first-time TDE bootstrap loudly. This runs
+    # only during initial initialization (BOOTSTRAP=true), so there is no user data
+    # yet; wipe the half-initialized data dir and exit non-zero. That forces a full
+    # re-bootstrap on the next start instead of falling through to a keyless boot
+    # (which would silently disable encryption). The pod crash-loops visibly until
+    # the key provider is reachable.
+    tde_bootstrap_fatal() {
+        echo "pg_tde FATAL: $1"
+        pg_ctl -D "$PGDATA" -m immediate -w stop || true
+        rm -rf "${PGDATA:?}"/* || true
+        exit 1
+    }
     # Enable the extension in the default databases. template1 makes it the
     # default for future databases.
     for TDE_DB in template1 "$POSTGRES_DB"; do
@@ -185,14 +197,14 @@ SQL
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
-            || { echo "pg_tde FATAL: failed to set database principal key '${TDE_KEY_NAME}'"; exit 1; }
+            || tde_bootstrap_fatal "failed to set database principal key '${TDE_KEY_NAME}'"
     else
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
-            || { echo "pg_tde FATAL: failed to set global principal key '${TDE_KEY_NAME}'"; exit 1; }
+            || tde_bootstrap_fatal "failed to set global principal key '${TDE_KEY_NAME}'"
     fi
 
     # If WAL encryption is requested, create + set the server (WAL) key too (global only).
@@ -202,7 +214,7 @@ SQL
             || echo "pg_tde: create WAL server key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_server_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
-            || { echo "pg_tde FATAL: failed to set WAL server key '${TDE_KEY_NAME}-wal'"; exit 1; }
+            || tde_bootstrap_fatal "failed to set WAL server key '${TDE_KEY_NAME}-wal'"
     fi
 fi
 

--- a/role_scripts/13/primary/start.sh
+++ b/role_scripts/13/primary/start.sh
@@ -170,9 +170,15 @@ SQL
             ;;
     esac
 
-    # Set the per-database principal key.
-    psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-        "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+    # Set the per-database principal key with the setter that matches the
+    # provider scope: file providers are database-scoped, vault/kmip are global.
+    if [[ "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+    else
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+    fi
 
     # If WAL encryption is requested, set the server key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then

--- a/role_scripts/13/primary/start.sh
+++ b/role_scripts/13/primary/start.sh
@@ -173,8 +173,18 @@ SQL
     # Register the key provider (global preferred; file is standalone only).
     case "${TDE_PROVIDER_KIND:-}" in
         vault)
-            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-                "SELECT pg_tde_add_global_key_provider_vault_v2('${TDE_PROVIDER_NAME}','${TDE_VAULT_ADDR}','${TDE_VAULT_MOUNT}','${TDE_VAULT_TOKEN_PATH}','${TDE_VAULT_CA_PATH}');" || true
+            # pg_tde_add_global_key_provider_vault_v2 has a 5-arg form and a 6-arg
+            # form that also takes a Vault Enterprise namespace. Pass the namespace
+            # (spec.tde.keyProvider.vault.namespace -> TDE_VAULT_NAMESPACE) only when
+            # it is set, so the common namespace-less case keeps the 5-arg form; the
+            # namespace was otherwise accepted in the CRD but silently dropped here.
+            if [[ -n "${TDE_VAULT_NAMESPACE:-}" ]]; then
+                psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                    "SELECT pg_tde_add_global_key_provider_vault_v2('${TDE_PROVIDER_NAME}','${TDE_VAULT_ADDR}','${TDE_VAULT_MOUNT}','${TDE_VAULT_TOKEN_PATH}','${TDE_VAULT_CA_PATH}','${TDE_VAULT_NAMESPACE}');" || true
+            else
+                psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                    "SELECT pg_tde_add_global_key_provider_vault_v2('${TDE_PROVIDER_NAME}','${TDE_VAULT_ADDR}','${TDE_VAULT_MOUNT}','${TDE_VAULT_TOKEN_PATH}','${TDE_VAULT_CA_PATH}');" || true
+            fi
             ;;
         kmip)
             psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \

--- a/role_scripts/13/standby/ha_backup_job.sh
+++ b/role_scripts/13/standby/ha_backup_job.sh
@@ -59,10 +59,12 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     mkdir -p "$PGDATA"
     rm -rf "$PGDATA"/*
     chmod 0700 "$PGDATA"
+    BASEBACKUP=pg_basebackup
+    [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
     if [[ "${SSL:-0}" == "ON" ]]; then
-        pg_basebackup -X fetch --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
+        "$BASEBACKUP" -X fetch --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
     else
-        pg_basebackup -X fetch --no-password --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST"
+        "$BASEBACKUP" -X fetch --no-password --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST"
     fi
 fi
 
@@ -89,7 +91,16 @@ echo "wal_log_hints = on" >>/tmp/postgresql.conf
 # we are not doing any archiving by default but it's better to have this config in our postgresql.conf file in case of customization.
 echo "archive_mode = always" >>/tmp/postgresql.conf
 echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 
 if [ "$STANDBY" == "hot" ]; then
     echo "hot_standby = on" >>/tmp/postgresql.conf

--- a/role_scripts/13/standby/ha_backup_job.sh
+++ b/role_scripts/13/standby/ha_backup_job.sh
@@ -61,6 +61,7 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     chmod 0700 "$PGDATA"
     BASEBACKUP=pg_basebackup
     [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
+    echo "pg_tde: seeding standby with '$BASEBACKUP' (TDE_ENABLED=${TDE_ENABLED:-false})"
     if [[ "${SSL:-0}" == "ON" ]]; then
         "$BASEBACKUP" -X fetch --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
     else

--- a/role_scripts/13/standby/ha_backup_job.sh
+++ b/role_scripts/13/standby/ha_backup_job.sh
@@ -100,6 +100,7 @@ echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
     [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
     [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
     echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
 fi
 

--- a/role_scripts/13/standby/remote-replica.sh
+++ b/role_scripts/13/standby/remote-replica.sh
@@ -110,6 +110,7 @@ echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
     [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
     [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
     echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
 fi
 

--- a/role_scripts/13/standby/remote-replica.sh
+++ b/role_scripts/13/standby/remote-replica.sh
@@ -69,10 +69,12 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     mkdir -p "$PGDATA"
     rm -rf "$PGDATA"/*
     chmod 0700 "$PGDATA"
+    BASEBACKUP=pg_basebackup
+    [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
     if [[ "${SOURCE_SSL:-0}" == "ON" ]]; then
-        pg_basebackup -X fetch --pgdata "$PGDATA" --username=$PRIMARY_USER_NAME --progress --host="$PRIMARY_HOST" -d "sslmode=$SOURCE_SSL_MODE sslrootcert=/tls/certs/remote/ca.crt sslcert=/tls/certs/remote/client.crt sslkey=/tls/certs/remote/client.key"
+        "$BASEBACKUP" -X fetch --pgdata "$PGDATA" --username=$PRIMARY_USER_NAME --progress --host="$PRIMARY_HOST" -d "sslmode=$SOURCE_SSL_MODE sslrootcert=/tls/certs/remote/ca.crt sslcert=/tls/certs/remote/client.crt sslkey=/tls/certs/remote/client.key"
     else
-        pg_basebackup -X fetch --no-password --pgdata "$PGDATA" --username=$PRIMARY_USER_NAME --progress --host="$PRIMARY_HOST"
+        "$BASEBACKUP" -X fetch --no-password --pgdata "$PGDATA" --username=$PRIMARY_USER_NAME --progress --host="$PRIMARY_HOST"
     fi
 fi
 
@@ -99,7 +101,16 @@ echo "wal_log_hints = on" >>/tmp/postgresql.conf
 echo "archive_mode = always" >>/tmp/postgresql.conf
 echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
 
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 
 if [ "$STANDBY" == "hot" ]; then
     echo "hot_standby = on" >>/tmp/postgresql.conf

--- a/role_scripts/13/standby/remote-replica.sh
+++ b/role_scripts/13/standby/remote-replica.sh
@@ -71,6 +71,7 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     chmod 0700 "$PGDATA"
     BASEBACKUP=pg_basebackup
     [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
+    echo "pg_tde: seeding standby with '$BASEBACKUP' (TDE_ENABLED=${TDE_ENABLED:-false})"
     if [[ "${SOURCE_SSL:-0}" == "ON" ]]; then
         "$BASEBACKUP" -X fetch --pgdata "$PGDATA" --username=$PRIMARY_USER_NAME --progress --host="$PRIMARY_HOST" -d "sslmode=$SOURCE_SSL_MODE sslrootcert=/tls/certs/remote/ca.crt sslcert=/tls/certs/remote/client.crt sslkey=/tls/certs/remote/client.key"
     else

--- a/role_scripts/13/standby/run.sh
+++ b/role_scripts/13/standby/run.sh
@@ -169,6 +169,7 @@ echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
     [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
     [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
     echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
 fi
 

--- a/role_scripts/13/standby/run.sh
+++ b/role_scripts/13/standby/run.sh
@@ -89,7 +89,6 @@ if [[ "$WAL_LIMIT_POLICY" == "ReplicationSlot" ]]; then
   done
 fi
 
-
 if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     if [[ ! -e "/var/pv/IGNORE_FILESYSTEM_MOUNT_CHECK" ]]; then
       # Robust /var/pv mount availability check before any destructive operation or basebackup
@@ -117,10 +116,12 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     mkdir -p "$PGDATA"
     rm -rf "$PGDATA"/*
     chmod 0700 "$PGDATA"
+    BASEBACKUP=pg_basebackup
+    [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
     if [[ "${SSL:-0}" == "ON" ]]; then
-        pg_basebackup -Xs -c fast --pgdata "$PGDATA" --max-rate=1024M --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
+        "$BASEBACKUP" -Xs -c fast --pgdata "$PGDATA" --max-rate=1024M --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
     else
-        pg_basebackup -Xs -c fast --no-password --max-rate=1024M --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST"
+        "$BASEBACKUP" -Xs -c fast --no-password --max-rate=1024M --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST"
     fi
     touch /var/pv/data/standby.signal
 else
@@ -159,7 +160,16 @@ else
     echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
 fi
 
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 
 if [ "$STANDBY" == "hot" ]; then
     echo "hot_standby = on" >>/tmp/postgresql.conf

--- a/role_scripts/13/standby/run.sh
+++ b/role_scripts/13/standby/run.sh
@@ -118,6 +118,7 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     chmod 0700 "$PGDATA"
     BASEBACKUP=pg_basebackup
     [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
+    echo "pg_tde: seeding standby with '$BASEBACKUP' (TDE_ENABLED=${TDE_ENABLED:-false})"
     if [[ "${SSL:-0}" == "ON" ]]; then
         "$BASEBACKUP" -Xs -c fast --pgdata "$PGDATA" --max-rate=1024M --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
     else

--- a/role_scripts/13/standby/warm_stanby.sh
+++ b/role_scripts/13/standby/warm_stanby.sh
@@ -38,7 +38,16 @@ echo "archive_mode = always" >>/tmp/postgresql.conf
 echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
 
 echo "hot_standby = off" >>/tmp/postgresql.conf
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 
 if [[ "$STREAMING" == "synchronous" ]]; then
     # setup synchronous streaming replication

--- a/role_scripts/13/standby/warm_stanby.sh
+++ b/role_scripts/13/standby/warm_stanby.sh
@@ -46,6 +46,7 @@ echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
     [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
     [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
     echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
 fi
 

--- a/role_scripts/14/primary/start.sh
+++ b/role_scripts/14/primary/start.sh
@@ -150,6 +150,10 @@ echo
 # database and superuser exist and before any encrypted table or the
 # default_table_access_method flip can be used. Idempotent on retries.
 if [[ "${TDE_ENABLED:-false}" == "true" && "${BOOTSTRAP}" == "true" ]]; then
+    # Run every pg_tde key operation in this block at the configured cipher. The
+    # post-bootstrap config that carries pg_tde.cipher is not loaded yet, so without
+    # this the principal key would be created (and validated) at the wrong length.
+    export PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}"
     # Enable the extension in the default databases. template1 makes it the
     # default for future databases.
     for TDE_DB in template1 "$POSTGRES_DB"; do
@@ -180,14 +184,14 @@ SQL
     # Key setup is strict: a failure fails the bootstrap loudly rather than booting
     # with no principal key, which would silently break encrypted-table creation.
     if [[ "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
-        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || { echo "pg_tde FATAL: failed to set database principal key '${TDE_KEY_NAME}'"; exit 1; }
     else
-        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
@@ -197,7 +201,7 @@ SQL
 
     # If WAL encryption is requested, create + set the server (WAL) key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
-        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create WAL server key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
@@ -205,6 +209,8 @@ SQL
             || { echo "pg_tde FATAL: failed to set WAL server key '${TDE_KEY_NAME}-wal'"; exit 1; }
     fi
 fi
+
+unset PGOPTIONS
 
 if [[ "$BOOTSTRAP" == "true" ]];then
   # initialize database

--- a/role_scripts/14/primary/start.sh
+++ b/role_scripts/14/primary/start.sh
@@ -154,6 +154,18 @@ if [[ "${TDE_ENABLED:-false}" == "true" && "${BOOTSTRAP}" == "true" ]]; then
     # post-bootstrap config that carries pg_tde.cipher is not loaded yet, so without
     # this the principal key would be created (and validated) at the wrong length.
     export PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}"
+    # tde_bootstrap_fatal aborts a failed first-time TDE bootstrap loudly. This runs
+    # only during initial initialization (BOOTSTRAP=true), so there is no user data
+    # yet; wipe the half-initialized data dir and exit non-zero. That forces a full
+    # re-bootstrap on the next start instead of falling through to a keyless boot
+    # (which would silently disable encryption). The pod crash-loops visibly until
+    # the key provider is reachable.
+    tde_bootstrap_fatal() {
+        echo "pg_tde FATAL: $1"
+        pg_ctl -D "$PGDATA" -m immediate -w stop || true
+        rm -rf "${PGDATA:?}"/* || true
+        exit 1
+    }
     # Enable the extension in the default databases. template1 makes it the
     # default for future databases.
     for TDE_DB in template1 "$POSTGRES_DB"; do
@@ -189,14 +201,14 @@ SQL
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
-            || { echo "pg_tde FATAL: failed to set database principal key '${TDE_KEY_NAME}'"; exit 1; }
+            || tde_bootstrap_fatal "failed to set database principal key '${TDE_KEY_NAME}'"
     else
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
-            || { echo "pg_tde FATAL: failed to set global principal key '${TDE_KEY_NAME}'"; exit 1; }
+            || tde_bootstrap_fatal "failed to set global principal key '${TDE_KEY_NAME}'"
     fi
 
     # If WAL encryption is requested, create + set the server (WAL) key too (global only).
@@ -206,7 +218,7 @@ SQL
             || echo "pg_tde: create WAL server key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_server_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
-            || { echo "pg_tde FATAL: failed to set WAL server key '${TDE_KEY_NAME}-wal'"; exit 1; }
+            || tde_bootstrap_fatal "failed to set WAL server key '${TDE_KEY_NAME}-wal'"
     fi
 fi
 

--- a/role_scripts/14/primary/start.sh
+++ b/role_scripts/14/primary/start.sh
@@ -209,6 +209,22 @@ SQL
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || tde_bootstrap_fatal "failed to set global principal key '${TDE_KEY_NAME}'"
+
+        # Set a server-wide DEFAULT principal key so databases created later inherit
+        # encryption. pg_tde stores the principal key per database OID and CREATE
+        # DATABASE does NOT copy it (a key set in template1 is not carried to its
+        # clones), so without a server default the first encrypted CREATE TABLE in a
+        # newly created database fails "principal key not configured" under a
+        # cluster-wide default_table_access_method = tde_heap. The default key is a
+        # global-provider feature; the file keyring (standalone, database-scoped) has
+        # no server default, so this applies to the vault/kmip providers only. Create
+        # precedes set, and the set is strict like the principal-key set above.
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
+            || echo "pg_tde: create default key returned non-zero (may already exist), continuing to set"
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_default_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
+            || tde_bootstrap_fatal "failed to set default principal key '${TDE_KEY_NAME}-default'"
     fi
 
     # WAL encryption is global-only: the file keyring is a database-scoped

--- a/role_scripts/14/primary/start.sh
+++ b/role_scripts/14/primary/start.sh
@@ -177,8 +177,18 @@ SQL
     # Register the key provider (global preferred; file is standalone only).
     case "${TDE_PROVIDER_KIND:-}" in
         vault)
-            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-                "SELECT pg_tde_add_global_key_provider_vault_v2('${TDE_PROVIDER_NAME}','${TDE_VAULT_ADDR}','${TDE_VAULT_MOUNT}','${TDE_VAULT_TOKEN_PATH}','${TDE_VAULT_CA_PATH}');" || true
+            # pg_tde_add_global_key_provider_vault_v2 has a 5-arg form and a 6-arg
+            # form that also takes a Vault Enterprise namespace. Pass the namespace
+            # (spec.tde.keyProvider.vault.namespace -> TDE_VAULT_NAMESPACE) only when
+            # it is set, so the common namespace-less case keeps the 5-arg form; the
+            # namespace was otherwise accepted in the CRD but silently dropped here.
+            if [[ -n "${TDE_VAULT_NAMESPACE:-}" ]]; then
+                psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                    "SELECT pg_tde_add_global_key_provider_vault_v2('${TDE_PROVIDER_NAME}','${TDE_VAULT_ADDR}','${TDE_VAULT_MOUNT}','${TDE_VAULT_TOKEN_PATH}','${TDE_VAULT_CA_PATH}','${TDE_VAULT_NAMESPACE}');" || true
+            else
+                psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                    "SELECT pg_tde_add_global_key_provider_vault_v2('${TDE_PROVIDER_NAME}','${TDE_VAULT_ADDR}','${TDE_VAULT_MOUNT}','${TDE_VAULT_TOKEN_PATH}','${TDE_VAULT_CA_PATH}');" || true
+            fi
             ;;
         kmip)
             psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \

--- a/role_scripts/14/primary/start.sh
+++ b/role_scripts/14/primary/start.sh
@@ -180,14 +180,14 @@ SQL
     # Key setup is strict: a failure fails the bootstrap loudly rather than booting
     # with no principal key, which would silently break encrypted-table creation.
     if [[ "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || { echo "pg_tde FATAL: failed to set database principal key '${TDE_KEY_NAME}'"; exit 1; }
     else
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
@@ -197,7 +197,7 @@ SQL
 
     # If WAL encryption is requested, create + set the server (WAL) key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create WAL server key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \

--- a/role_scripts/14/primary/start.sh
+++ b/role_scripts/14/primary/start.sh
@@ -174,9 +174,15 @@ SQL
             ;;
     esac
 
-    # Set the per-database principal key.
-    psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-        "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+    # Set the per-database principal key with the setter that matches the
+    # provider scope: file providers are database-scoped, vault/kmip are global.
+    if [[ "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+    else
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+    fi
 
     # If WAL encryption is requested, set the server key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then

--- a/role_scripts/14/primary/start.sh
+++ b/role_scripts/14/primary/start.sh
@@ -214,17 +214,22 @@ SQL
         # encryption. pg_tde stores the principal key per database OID and CREATE
         # DATABASE does NOT copy it (a key set in template1 is not carried to its
         # clones), so without a server default the first encrypted CREATE TABLE in a
-        # newly created database fails "principal key not configured" under a
-        # cluster-wide default_table_access_method = tde_heap. The default key is a
-        # global-provider feature; the file keyring (standalone, database-scoped) has
-        # no server default, so this applies to the vault/kmip providers only. Create
-        # precedes set, and the set is strict like the principal-key set above.
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
-            || echo "pg_tde: create default key returned non-zero (may already exist), continuing to set"
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_set_default_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
-            || tde_bootstrap_fatal "failed to set default principal key '${TDE_KEY_NAME}-default'"
+        # newly created database fails "principal key not configured". This only
+        # matters when new tables are encrypted by default or enforced cluster-wide,
+        # so gate it on TDE_DEFAULT_AM/TDE_ENFORCE (mirroring how the WAL block below
+        # gates on TDE_ENCRYPT_WAL): a plain opt-in-per-table cluster does not need a
+        # server default and should not take the strict-set crash-loop risk for it.
+        # The default key is a global-provider feature; the file keyring (standalone,
+        # database-scoped) has no server default, so this applies to vault/kmip only.
+        # Create precedes set, and the set is strict like the principal-key set above.
+        if [[ "${TDE_DEFAULT_AM:-false}" == "true" || "${TDE_ENFORCE:-false}" == "true" ]]; then
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
+                || echo "pg_tde: create default key returned non-zero (may already exist), continuing to set"
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_set_default_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
+                || tde_bootstrap_fatal "failed to set default principal key '${TDE_KEY_NAME}-default'"
+        fi
     fi
 
     # WAL encryption is global-only: the file keyring is a database-scoped

--- a/role_scripts/14/primary/start.sh
+++ b/role_scripts/14/primary/start.sh
@@ -42,7 +42,11 @@ else
     echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
 fi
 
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 
 if [[ "${SSL:-0}" == "ON" ]]; then
     echo "ssl =on" >>/tmp/postgresql.conf
@@ -58,8 +62,6 @@ fi
 if [[ "$CLIENT_AUTH_MODE" == "scram" ]]; then
     echo "password_encryption = scram-sha-256" >>/tmp/postgresql.conf
 fi
-
-
 
 # ****************** Recovery config **************************
 echo "recovery_target_timeline = 'latest'" >>/tmp/postgresql.conf
@@ -143,6 +145,45 @@ echo
 
 psql+=(--username "$POSTGRES_USER" --dbname "$POSTGRES_DB")
 echo
+
+# pg_tde principal-key bootstrap. Runs once on first initialization, after the
+# database and superuser exist and before any encrypted table or the
+# default_table_access_method flip can be used. Idempotent on retries.
+if [[ "${TDE_ENABLED:-false}" == "true" && "${BOOTSTRAP}" == "true" ]]; then
+    # Enable the extension in the default databases. template1 makes it the
+    # default for future databases.
+    for TDE_DB in template1 "$POSTGRES_DB"; do
+        psql -U postgres -d "$TDE_DB" -v ON_ERROR_STOP=1 <<SQL
+CREATE EXTENSION IF NOT EXISTS ${TDE_EXTENSION:-pg_tde};
+SQL
+    done
+
+    # Register the key provider (global preferred; file is standalone only).
+    case "${TDE_PROVIDER_KIND:-}" in
+        vault)
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_add_global_key_provider_vault_v2('${TDE_PROVIDER_NAME}','${TDE_VAULT_ADDR}','${TDE_VAULT_MOUNT}','${TDE_VAULT_TOKEN_PATH}','${TDE_VAULT_CA_PATH}');" || true
+            ;;
+        kmip)
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_add_global_key_provider_kmip('${TDE_PROVIDER_NAME}','${TDE_KMIP_ADDR}',${TDE_KMIP_PORT},'${TDE_KMIP_CLIENT_CERT_PATH}','${TDE_KMIP_CLIENT_KEY_PATH}','${TDE_KMIP_CA_PATH}');" || true
+            ;;
+        file)
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_add_database_key_provider_file('${TDE_PROVIDER_NAME}','${TDE_FILE_PATH}');" || true
+            ;;
+    esac
+
+    # Set the per-database principal key.
+    psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+
+    # If WAL encryption is requested, set the server key too (global only).
+    if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_server_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" || true
+    fi
+fi
 
 if [[ "$BOOTSTRAP" == "true" ]];then
   # initialize database
@@ -270,6 +311,14 @@ fi
 mv /tmp/pg_hba.conf "$PGDATA/pg_hba.conf"
 
 touch /tmp/postgresql.conf
+# pg_tde runtime GUCs. Authored in the post-bootstrap rewrite, after the
+# extension and principal key exist, so default_table_access_method is safe.
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 if [ "$STANDBY" == "hot" ]; then
     echo "hot_standby = on" >>/tmp/postgresql.conf
 else

--- a/role_scripts/14/primary/start.sh
+++ b/role_scripts/14/primary/start.sh
@@ -174,20 +174,35 @@ SQL
             ;;
     esac
 
-    # Set the per-database principal key with the setter that matches the
-    # provider scope: file providers are database-scoped, vault/kmip are global.
+    # Create then set the per-database principal key. pg_tde requires the key to
+    # exist before it can be set as principal, so create precedes set. The setter
+    # matches the provider scope (file is database-scoped, vault/kmip are global).
+    # Key setup is strict: a failure fails the bootstrap loudly rather than booting
+    # with no principal key, which would silently break encrypted-table creation.
     if [[ "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+            "SELECT pg_tde_create_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
+            || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
+            || { echo "pg_tde FATAL: failed to set database principal key '${TDE_KEY_NAME}'"; exit 1; }
     else
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+            "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
+            || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
+            || { echo "pg_tde FATAL: failed to set global principal key '${TDE_KEY_NAME}'"; exit 1; }
     fi
 
-    # If WAL encryption is requested, set the server key too (global only).
+    # If WAL encryption is requested, create + set the server (WAL) key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_set_server_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" || true
+            "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
+            || echo "pg_tde: create WAL server key returned non-zero (may already exist), continuing to set"
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_server_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
+            || { echo "pg_tde FATAL: failed to set WAL server key '${TDE_KEY_NAME}-wal'"; exit 1; }
     fi
 fi
 

--- a/role_scripts/14/primary/start.sh
+++ b/role_scripts/14/primary/start.sh
@@ -211,6 +211,13 @@ SQL
             || tde_bootstrap_fatal "failed to set global principal key '${TDE_KEY_NAME}'"
     fi
 
+    # WAL encryption is global-only: the file keyring is a database-scoped
+    # provider and cannot back a server key. The operator webhook already rejects
+    # this combination, so this is a fail-closed backstop with a clear message
+    # (instead of a swallowed error that crash-loops on the misleading set-key fatal).
+    if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" && "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
+        tde_bootstrap_fatal "WAL encryption requires a global (vault or kmip) key provider; the file keyring cannot back WAL encryption"
+    fi
     # If WAL encryption is requested, create + set the server (WAL) key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \

--- a/role_scripts/14/standby/ha_backup_job.sh
+++ b/role_scripts/14/standby/ha_backup_job.sh
@@ -61,6 +61,7 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     chmod 0700 "$PGDATA"
     BASEBACKUP=pg_basebackup
     [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
+    echo "pg_tde: seeding standby with '$BASEBACKUP' (TDE_ENABLED=${TDE_ENABLED:-false})"
     if [[ "${SSL:-0}" == "ON" ]]; then
         "$BASEBACKUP" -X fetch --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
     else

--- a/role_scripts/14/standby/ha_backup_job.sh
+++ b/role_scripts/14/standby/ha_backup_job.sh
@@ -59,10 +59,12 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     mkdir -p "$PGDATA"
     rm -rf "$PGDATA"/*
     chmod 0700 "$PGDATA"
+    BASEBACKUP=pg_basebackup
+    [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
     if [[ "${SSL:-0}" == "ON" ]]; then
-        pg_basebackup -X fetch --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
+        "$BASEBACKUP" -X fetch --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
     else
-        pg_basebackup -X fetch --no-password --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST"
+        "$BASEBACKUP" -X fetch --no-password --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST"
     fi
 fi
 
@@ -89,7 +91,16 @@ echo "wal_log_hints = on" >>/tmp/postgresql.conf
 echo "archive_mode = always" >>/tmp/postgresql.conf
 echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
 
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 
 if [ "$STANDBY" == "hot" ]; then
     echo "hot_standby = on" >>/tmp/postgresql.conf

--- a/role_scripts/14/standby/ha_backup_job.sh
+++ b/role_scripts/14/standby/ha_backup_job.sh
@@ -100,6 +100,7 @@ echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
     [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
     [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
     echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
 fi
 

--- a/role_scripts/14/standby/remote-replica.sh
+++ b/role_scripts/14/standby/remote-replica.sh
@@ -110,6 +110,7 @@ echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
     [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
     [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
     echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
 fi
 

--- a/role_scripts/14/standby/remote-replica.sh
+++ b/role_scripts/14/standby/remote-replica.sh
@@ -69,10 +69,12 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     mkdir -p "$PGDATA"
     rm -rf "$PGDATA"/*
     chmod 0700 "$PGDATA"
+    BASEBACKUP=pg_basebackup
+    [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
     if [[ "${SOURCE_SSL:-0}" == "ON" ]]; then
-        pg_basebackup -X fetch --pgdata "$PGDATA" --username=$PRIMARY_USER_NAME --progress --host="$PRIMARY_HOST" -d "sslmode=$SOURCE_SSL_MODE sslrootcert=/tls/certs/remote/ca.crt sslcert=/tls/certs/remote/client.crt sslkey=/tls/certs/remote/client.key"
+        "$BASEBACKUP" -X fetch --pgdata "$PGDATA" --username=$PRIMARY_USER_NAME --progress --host="$PRIMARY_HOST" -d "sslmode=$SOURCE_SSL_MODE sslrootcert=/tls/certs/remote/ca.crt sslcert=/tls/certs/remote/client.crt sslkey=/tls/certs/remote/client.key"
     else
-        pg_basebackup -X fetch --no-password --pgdata "$PGDATA" --username=$PRIMARY_USER_NAME --progress --host="$PRIMARY_HOST"
+        "$BASEBACKUP" -X fetch --no-password --pgdata "$PGDATA" --username=$PRIMARY_USER_NAME --progress --host="$PRIMARY_HOST"
     fi
 fi
 
@@ -99,7 +101,16 @@ echo "wal_log_hints = on" >>/tmp/postgresql.conf
 echo "archive_mode = always" >>/tmp/postgresql.conf
 echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
 
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 
 if [ "$STANDBY" == "hot" ]; then
     echo "hot_standby = on" >>/tmp/postgresql.conf

--- a/role_scripts/14/standby/remote-replica.sh
+++ b/role_scripts/14/standby/remote-replica.sh
@@ -71,6 +71,7 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     chmod 0700 "$PGDATA"
     BASEBACKUP=pg_basebackup
     [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
+    echo "pg_tde: seeding standby with '$BASEBACKUP' (TDE_ENABLED=${TDE_ENABLED:-false})"
     if [[ "${SOURCE_SSL:-0}" == "ON" ]]; then
         "$BASEBACKUP" -X fetch --pgdata "$PGDATA" --username=$PRIMARY_USER_NAME --progress --host="$PRIMARY_HOST" -d "sslmode=$SOURCE_SSL_MODE sslrootcert=/tls/certs/remote/ca.crt sslcert=/tls/certs/remote/client.crt sslkey=/tls/certs/remote/client.key"
     else

--- a/role_scripts/14/standby/run.sh
+++ b/role_scripts/14/standby/run.sh
@@ -169,6 +169,7 @@ echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
     [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
     [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
     echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
 fi
 

--- a/role_scripts/14/standby/run.sh
+++ b/role_scripts/14/standby/run.sh
@@ -89,7 +89,6 @@ if [[ "$WAL_LIMIT_POLICY" == "ReplicationSlot" ]]; then
   done
 fi
 
-
 if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     if [[ ! -e "/var/pv/IGNORE_FILESYSTEM_MOUNT_CHECK" ]]; then
       # Robust /var/pv mount availability check before any destructive operation or basebackup
@@ -117,10 +116,12 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     mkdir -p "$PGDATA"
     rm -rf "$PGDATA"/*
     chmod 0700 "$PGDATA"
+    BASEBACKUP=pg_basebackup
+    [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
     if [[ "${SSL:-0}" == "ON" ]]; then
-        pg_basebackup -Xs -c fast --pgdata "$PGDATA" --max-rate=1024M --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
+        "$BASEBACKUP" -Xs -c fast --pgdata "$PGDATA" --max-rate=1024M --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
     else
-        pg_basebackup -Xs -c fast --no-password --max-rate=1024M --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST"
+        "$BASEBACKUP" -Xs -c fast --no-password --max-rate=1024M --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST"
     fi
     touch /var/pv/data/standby.signal
 else
@@ -159,7 +160,16 @@ else
     echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
 fi
 
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 
 if [ "$STANDBY" == "hot" ]; then
     echo "hot_standby = on" >>/tmp/postgresql.conf

--- a/role_scripts/14/standby/run.sh
+++ b/role_scripts/14/standby/run.sh
@@ -118,6 +118,7 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     chmod 0700 "$PGDATA"
     BASEBACKUP=pg_basebackup
     [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
+    echo "pg_tde: seeding standby with '$BASEBACKUP' (TDE_ENABLED=${TDE_ENABLED:-false})"
     if [[ "${SSL:-0}" == "ON" ]]; then
         "$BASEBACKUP" -Xs -c fast --pgdata "$PGDATA" --max-rate=1024M --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
     else

--- a/role_scripts/14/standby/warm_stanby.sh
+++ b/role_scripts/14/standby/warm_stanby.sh
@@ -38,7 +38,16 @@ echo "archive_mode = always" >>/tmp/postgresql.conf
 echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
 
 echo "hot_standby = off" >>/tmp/postgresql.conf
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 
 if [[ "$STREAMING" == "synchronous" ]]; then
     # setup synchronous streaming replication

--- a/role_scripts/14/standby/warm_stanby.sh
+++ b/role_scripts/14/standby/warm_stanby.sh
@@ -46,6 +46,7 @@ echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
     [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
     [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
     echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
 fi
 

--- a/role_scripts/15/primary/start.sh
+++ b/role_scripts/15/primary/start.sh
@@ -153,6 +153,10 @@ echo
 # database and superuser exist and before any encrypted table or the
 # default_table_access_method flip can be used. Idempotent on retries.
 if [[ "${TDE_ENABLED:-false}" == "true" && "${BOOTSTRAP}" == "true" ]]; then
+    # Run every pg_tde key operation in this block at the configured cipher. The
+    # post-bootstrap config that carries pg_tde.cipher is not loaded yet, so without
+    # this the principal key would be created (and validated) at the wrong length.
+    export PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}"
     # Enable the extension in the default databases. template1 makes it the
     # default for future databases.
     for TDE_DB in template1 "$POSTGRES_DB"; do
@@ -183,14 +187,14 @@ SQL
     # Key setup is strict: a failure fails the bootstrap loudly rather than booting
     # with no principal key, which would silently break encrypted-table creation.
     if [[ "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
-        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || { echo "pg_tde FATAL: failed to set database principal key '${TDE_KEY_NAME}'"; exit 1; }
     else
-        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
@@ -200,7 +204,7 @@ SQL
 
     # If WAL encryption is requested, create + set the server (WAL) key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
-        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create WAL server key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
@@ -208,6 +212,8 @@ SQL
             || { echo "pg_tde FATAL: failed to set WAL server key '${TDE_KEY_NAME}-wal'"; exit 1; }
     fi
 fi
+
+unset PGOPTIONS
 
 if [[ "$BOOTSTRAP" == "true" ]];then
   # initialize database

--- a/role_scripts/15/primary/start.sh
+++ b/role_scripts/15/primary/start.sh
@@ -183,14 +183,14 @@ SQL
     # Key setup is strict: a failure fails the bootstrap loudly rather than booting
     # with no principal key, which would silently break encrypted-table creation.
     if [[ "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || { echo "pg_tde FATAL: failed to set database principal key '${TDE_KEY_NAME}'"; exit 1; }
     else
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
@@ -200,7 +200,7 @@ SQL
 
     # If WAL encryption is requested, create + set the server (WAL) key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create WAL server key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \

--- a/role_scripts/15/primary/start.sh
+++ b/role_scripts/15/primary/start.sh
@@ -217,17 +217,22 @@ SQL
         # encryption. pg_tde stores the principal key per database OID and CREATE
         # DATABASE does NOT copy it (a key set in template1 is not carried to its
         # clones), so without a server default the first encrypted CREATE TABLE in a
-        # newly created database fails "principal key not configured" under a
-        # cluster-wide default_table_access_method = tde_heap. The default key is a
-        # global-provider feature; the file keyring (standalone, database-scoped) has
-        # no server default, so this applies to the vault/kmip providers only. Create
-        # precedes set, and the set is strict like the principal-key set above.
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
-            || echo "pg_tde: create default key returned non-zero (may already exist), continuing to set"
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_set_default_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
-            || tde_bootstrap_fatal "failed to set default principal key '${TDE_KEY_NAME}-default'"
+        # newly created database fails "principal key not configured". This only
+        # matters when new tables are encrypted by default or enforced cluster-wide,
+        # so gate it on TDE_DEFAULT_AM/TDE_ENFORCE (mirroring how the WAL block below
+        # gates on TDE_ENCRYPT_WAL): a plain opt-in-per-table cluster does not need a
+        # server default and should not take the strict-set crash-loop risk for it.
+        # The default key is a global-provider feature; the file keyring (standalone,
+        # database-scoped) has no server default, so this applies to vault/kmip only.
+        # Create precedes set, and the set is strict like the principal-key set above.
+        if [[ "${TDE_DEFAULT_AM:-false}" == "true" || "${TDE_ENFORCE:-false}" == "true" ]]; then
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
+                || echo "pg_tde: create default key returned non-zero (may already exist), continuing to set"
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_set_default_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
+                || tde_bootstrap_fatal "failed to set default principal key '${TDE_KEY_NAME}-default'"
+        fi
     fi
 
     # WAL encryption is global-only: the file keyring is a database-scoped

--- a/role_scripts/15/primary/start.sh
+++ b/role_scripts/15/primary/start.sh
@@ -180,8 +180,18 @@ SQL
     # Register the key provider (global preferred; file is standalone only).
     case "${TDE_PROVIDER_KIND:-}" in
         vault)
-            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-                "SELECT pg_tde_add_global_key_provider_vault_v2('${TDE_PROVIDER_NAME}','${TDE_VAULT_ADDR}','${TDE_VAULT_MOUNT}','${TDE_VAULT_TOKEN_PATH}','${TDE_VAULT_CA_PATH}');" || true
+            # pg_tde_add_global_key_provider_vault_v2 has a 5-arg form and a 6-arg
+            # form that also takes a Vault Enterprise namespace. Pass the namespace
+            # (spec.tde.keyProvider.vault.namespace -> TDE_VAULT_NAMESPACE) only when
+            # it is set, so the common namespace-less case keeps the 5-arg form; the
+            # namespace was otherwise accepted in the CRD but silently dropped here.
+            if [[ -n "${TDE_VAULT_NAMESPACE:-}" ]]; then
+                psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                    "SELECT pg_tde_add_global_key_provider_vault_v2('${TDE_PROVIDER_NAME}','${TDE_VAULT_ADDR}','${TDE_VAULT_MOUNT}','${TDE_VAULT_TOKEN_PATH}','${TDE_VAULT_CA_PATH}','${TDE_VAULT_NAMESPACE}');" || true
+            else
+                psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                    "SELECT pg_tde_add_global_key_provider_vault_v2('${TDE_PROVIDER_NAME}','${TDE_VAULT_ADDR}','${TDE_VAULT_MOUNT}','${TDE_VAULT_TOKEN_PATH}','${TDE_VAULT_CA_PATH}');" || true
+            fi
             ;;
         kmip)
             psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \

--- a/role_scripts/15/primary/start.sh
+++ b/role_scripts/15/primary/start.sh
@@ -214,6 +214,13 @@ SQL
             || tde_bootstrap_fatal "failed to set global principal key '${TDE_KEY_NAME}'"
     fi
 
+    # WAL encryption is global-only: the file keyring is a database-scoped
+    # provider and cannot back a server key. The operator webhook already rejects
+    # this combination, so this is a fail-closed backstop with a clear message
+    # (instead of a swallowed error that crash-loops on the misleading set-key fatal).
+    if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" && "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
+        tde_bootstrap_fatal "WAL encryption requires a global (vault or kmip) key provider; the file keyring cannot back WAL encryption"
+    fi
     # If WAL encryption is requested, create + set the server (WAL) key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \

--- a/role_scripts/15/primary/start.sh
+++ b/role_scripts/15/primary/start.sh
@@ -177,9 +177,15 @@ SQL
             ;;
     esac
 
-    # Set the per-database principal key.
-    psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-        "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+    # Set the per-database principal key with the setter that matches the
+    # provider scope: file providers are database-scoped, vault/kmip are global.
+    if [[ "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+    else
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+    fi
 
     # If WAL encryption is requested, set the server key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then

--- a/role_scripts/15/primary/start.sh
+++ b/role_scripts/15/primary/start.sh
@@ -42,7 +42,11 @@ else
     echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
 fi
 
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 
 if [[ "${SSL:-0}" == "ON" ]]; then
     echo "ssl =on" >>/tmp/postgresql.conf
@@ -144,6 +148,45 @@ echo
 
 psql+=(--username "$POSTGRES_USER" --dbname "$POSTGRES_DB")
 echo
+
+# pg_tde principal-key bootstrap. Runs once on first initialization, after the
+# database and superuser exist and before any encrypted table or the
+# default_table_access_method flip can be used. Idempotent on retries.
+if [[ "${TDE_ENABLED:-false}" == "true" && "${BOOTSTRAP}" == "true" ]]; then
+    # Enable the extension in the default databases. template1 makes it the
+    # default for future databases.
+    for TDE_DB in template1 "$POSTGRES_DB"; do
+        psql -U postgres -d "$TDE_DB" -v ON_ERROR_STOP=1 <<SQL
+CREATE EXTENSION IF NOT EXISTS ${TDE_EXTENSION:-pg_tde};
+SQL
+    done
+
+    # Register the key provider (global preferred; file is standalone only).
+    case "${TDE_PROVIDER_KIND:-}" in
+        vault)
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_add_global_key_provider_vault_v2('${TDE_PROVIDER_NAME}','${TDE_VAULT_ADDR}','${TDE_VAULT_MOUNT}','${TDE_VAULT_TOKEN_PATH}','${TDE_VAULT_CA_PATH}');" || true
+            ;;
+        kmip)
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_add_global_key_provider_kmip('${TDE_PROVIDER_NAME}','${TDE_KMIP_ADDR}',${TDE_KMIP_PORT},'${TDE_KMIP_CLIENT_CERT_PATH}','${TDE_KMIP_CLIENT_KEY_PATH}','${TDE_KMIP_CA_PATH}');" || true
+            ;;
+        file)
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_add_database_key_provider_file('${TDE_PROVIDER_NAME}','${TDE_FILE_PATH}');" || true
+            ;;
+    esac
+
+    # Set the per-database principal key.
+    psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+
+    # If WAL encryption is requested, set the server key too (global only).
+    if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_server_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" || true
+    fi
+fi
 
 if [[ "$BOOTSTRAP" == "true" ]];then
   # initialize database
@@ -271,6 +314,14 @@ fi
 mv /tmp/pg_hba.conf "$PGDATA/pg_hba.conf"
 
 touch /tmp/postgresql.conf
+# pg_tde runtime GUCs. Authored in the post-bootstrap rewrite, after the
+# extension and principal key exist, so default_table_access_method is safe.
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 if [ "$STANDBY" == "hot" ]; then
     echo "hot_standby = on" >>/tmp/postgresql.conf
 else

--- a/role_scripts/15/primary/start.sh
+++ b/role_scripts/15/primary/start.sh
@@ -157,6 +157,18 @@ if [[ "${TDE_ENABLED:-false}" == "true" && "${BOOTSTRAP}" == "true" ]]; then
     # post-bootstrap config that carries pg_tde.cipher is not loaded yet, so without
     # this the principal key would be created (and validated) at the wrong length.
     export PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}"
+    # tde_bootstrap_fatal aborts a failed first-time TDE bootstrap loudly. This runs
+    # only during initial initialization (BOOTSTRAP=true), so there is no user data
+    # yet; wipe the half-initialized data dir and exit non-zero. That forces a full
+    # re-bootstrap on the next start instead of falling through to a keyless boot
+    # (which would silently disable encryption). The pod crash-loops visibly until
+    # the key provider is reachable.
+    tde_bootstrap_fatal() {
+        echo "pg_tde FATAL: $1"
+        pg_ctl -D "$PGDATA" -m immediate -w stop || true
+        rm -rf "${PGDATA:?}"/* || true
+        exit 1
+    }
     # Enable the extension in the default databases. template1 makes it the
     # default for future databases.
     for TDE_DB in template1 "$POSTGRES_DB"; do
@@ -192,14 +204,14 @@ SQL
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
-            || { echo "pg_tde FATAL: failed to set database principal key '${TDE_KEY_NAME}'"; exit 1; }
+            || tde_bootstrap_fatal "failed to set database principal key '${TDE_KEY_NAME}'"
     else
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
-            || { echo "pg_tde FATAL: failed to set global principal key '${TDE_KEY_NAME}'"; exit 1; }
+            || tde_bootstrap_fatal "failed to set global principal key '${TDE_KEY_NAME}'"
     fi
 
     # If WAL encryption is requested, create + set the server (WAL) key too (global only).
@@ -209,7 +221,7 @@ SQL
             || echo "pg_tde: create WAL server key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_server_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
-            || { echo "pg_tde FATAL: failed to set WAL server key '${TDE_KEY_NAME}-wal'"; exit 1; }
+            || tde_bootstrap_fatal "failed to set WAL server key '${TDE_KEY_NAME}-wal'"
     fi
 fi
 

--- a/role_scripts/15/primary/start.sh
+++ b/role_scripts/15/primary/start.sh
@@ -212,6 +212,22 @@ SQL
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || tde_bootstrap_fatal "failed to set global principal key '${TDE_KEY_NAME}'"
+
+        # Set a server-wide DEFAULT principal key so databases created later inherit
+        # encryption. pg_tde stores the principal key per database OID and CREATE
+        # DATABASE does NOT copy it (a key set in template1 is not carried to its
+        # clones), so without a server default the first encrypted CREATE TABLE in a
+        # newly created database fails "principal key not configured" under a
+        # cluster-wide default_table_access_method = tde_heap. The default key is a
+        # global-provider feature; the file keyring (standalone, database-scoped) has
+        # no server default, so this applies to the vault/kmip providers only. Create
+        # precedes set, and the set is strict like the principal-key set above.
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
+            || echo "pg_tde: create default key returned non-zero (may already exist), continuing to set"
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_default_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
+            || tde_bootstrap_fatal "failed to set default principal key '${TDE_KEY_NAME}-default'"
     fi
 
     # WAL encryption is global-only: the file keyring is a database-scoped

--- a/role_scripts/15/primary/start.sh
+++ b/role_scripts/15/primary/start.sh
@@ -177,20 +177,35 @@ SQL
             ;;
     esac
 
-    # Set the per-database principal key with the setter that matches the
-    # provider scope: file providers are database-scoped, vault/kmip are global.
+    # Create then set the per-database principal key. pg_tde requires the key to
+    # exist before it can be set as principal, so create precedes set. The setter
+    # matches the provider scope (file is database-scoped, vault/kmip are global).
+    # Key setup is strict: a failure fails the bootstrap loudly rather than booting
+    # with no principal key, which would silently break encrypted-table creation.
     if [[ "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+            "SELECT pg_tde_create_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
+            || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
+            || { echo "pg_tde FATAL: failed to set database principal key '${TDE_KEY_NAME}'"; exit 1; }
     else
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+            "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
+            || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
+            || { echo "pg_tde FATAL: failed to set global principal key '${TDE_KEY_NAME}'"; exit 1; }
     fi
 
-    # If WAL encryption is requested, set the server key too (global only).
+    # If WAL encryption is requested, create + set the server (WAL) key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_set_server_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" || true
+            "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
+            || echo "pg_tde: create WAL server key returned non-zero (may already exist), continuing to set"
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_server_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
+            || { echo "pg_tde FATAL: failed to set WAL server key '${TDE_KEY_NAME}-wal'"; exit 1; }
     fi
 fi
 

--- a/role_scripts/15/standby/ha_backup_job.sh
+++ b/role_scripts/15/standby/ha_backup_job.sh
@@ -102,6 +102,7 @@ echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
     [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
     [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
     echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
 fi
 

--- a/role_scripts/15/standby/ha_backup_job.sh
+++ b/role_scripts/15/standby/ha_backup_job.sh
@@ -63,6 +63,7 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     chmod 0700 "$PGDATA"
     BASEBACKUP=pg_basebackup
     [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
+    echo "pg_tde: seeding standby with '$BASEBACKUP' (TDE_ENABLED=${TDE_ENABLED:-false})"
     if [[ "${SSL:-0}" == "ON" ]]; then
         "$BASEBACKUP" -X fetch --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
     else

--- a/role_scripts/15/standby/ha_backup_job.sh
+++ b/role_scripts/15/standby/ha_backup_job.sh
@@ -61,10 +61,12 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     mkdir -p "$PGDATA"
     rm -rf "$PGDATA"/*
     chmod 0700 "$PGDATA"
+    BASEBACKUP=pg_basebackup
+    [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
     if [[ "${SSL:-0}" == "ON" ]]; then
-        pg_basebackup -X fetch --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
+        "$BASEBACKUP" -X fetch --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
     else
-        pg_basebackup -X fetch --no-password --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST"
+        "$BASEBACKUP" -X fetch --no-password --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST"
     fi
 fi
 
@@ -91,7 +93,16 @@ echo "wal_log_hints = on" >>/tmp/postgresql.conf
 echo "archive_mode = always" >>/tmp/postgresql.conf
 echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
 
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 
 if [ "$STANDBY" == "hot" ]; then
     echo "hot_standby = on" >>/tmp/postgresql.conf

--- a/role_scripts/15/standby/remote-replica.sh
+++ b/role_scripts/15/standby/remote-replica.sh
@@ -110,6 +110,7 @@ echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
     [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
     [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
     echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
 fi
 

--- a/role_scripts/15/standby/remote-replica.sh
+++ b/role_scripts/15/standby/remote-replica.sh
@@ -69,10 +69,12 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     mkdir -p "$PGDATA"
     rm -rf "$PGDATA"/*
     chmod 0700 "$PGDATA"
+    BASEBACKUP=pg_basebackup
+    [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
     if [[ "${SOURCE_SSL:-0}" == "ON" ]]; then
-        pg_basebackup -X fetch --pgdata "$PGDATA" --username=$PRIMARY_USER_NAME --progress --host="$PRIMARY_HOST" -d "sslmode=$SOURCE_SSL_MODE sslrootcert=/tls/certs/remote/ca.crt sslcert=/tls/certs/remote/client.crt sslkey=/tls/certs/remote/client.key"
+        "$BASEBACKUP" -X fetch --pgdata "$PGDATA" --username=$PRIMARY_USER_NAME --progress --host="$PRIMARY_HOST" -d "sslmode=$SOURCE_SSL_MODE sslrootcert=/tls/certs/remote/ca.crt sslcert=/tls/certs/remote/client.crt sslkey=/tls/certs/remote/client.key"
     else
-        pg_basebackup -X fetch --no-password --pgdata "$PGDATA" --username=$PRIMARY_USER_NAME --progress --host="$PRIMARY_HOST"
+        "$BASEBACKUP" -X fetch --no-password --pgdata "$PGDATA" --username=$PRIMARY_USER_NAME --progress --host="$PRIMARY_HOST"
     fi
 fi
 
@@ -99,7 +101,16 @@ echo "wal_log_hints = on" >>/tmp/postgresql.conf
 echo "archive_mode = always" >>/tmp/postgresql.conf
 echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
 
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 
 if [ "$STANDBY" == "hot" ]; then
     echo "hot_standby = on" >>/tmp/postgresql.conf

--- a/role_scripts/15/standby/remote-replica.sh
+++ b/role_scripts/15/standby/remote-replica.sh
@@ -71,6 +71,7 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     chmod 0700 "$PGDATA"
     BASEBACKUP=pg_basebackup
     [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
+    echo "pg_tde: seeding standby with '$BASEBACKUP' (TDE_ENABLED=${TDE_ENABLED:-false})"
     if [[ "${SOURCE_SSL:-0}" == "ON" ]]; then
         "$BASEBACKUP" -X fetch --pgdata "$PGDATA" --username=$PRIMARY_USER_NAME --progress --host="$PRIMARY_HOST" -d "sslmode=$SOURCE_SSL_MODE sslrootcert=/tls/certs/remote/ca.crt sslcert=/tls/certs/remote/client.crt sslkey=/tls/certs/remote/client.key"
     else

--- a/role_scripts/15/standby/run.sh
+++ b/role_scripts/15/standby/run.sh
@@ -117,6 +117,7 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     chmod 0700 "$PGDATA"
     BASEBACKUP=pg_basebackup
     [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
+    echo "pg_tde: seeding standby with '$BASEBACKUP' (TDE_ENABLED=${TDE_ENABLED:-false})"
     if [[ "${SSL:-0}" == "ON" ]]; then
         "$BASEBACKUP" -Xs -c fast --pgdata "$PGDATA" --max-rate=1024M --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
     else

--- a/role_scripts/15/standby/run.sh
+++ b/role_scripts/15/standby/run.sh
@@ -89,7 +89,6 @@ if [[ "$WAL_LIMIT_POLICY" == "ReplicationSlot" ]]; then
   done
 fi
 
-
 if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     if [[ ! -e "/var/pv/IGNORE_FILESYSTEM_MOUNT_CHECK" ]]; then
       pv_df_output=$(cat /proc/mounts)
@@ -116,10 +115,12 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     mkdir -p "$PGDATA"
     rm -rf "$PGDATA"/*
     chmod 0700 "$PGDATA"
+    BASEBACKUP=pg_basebackup
+    [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
     if [[ "${SSL:-0}" == "ON" ]]; then
-        pg_basebackup -Xs -c fast --pgdata "$PGDATA" --max-rate=1024M --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
+        "$BASEBACKUP" -Xs -c fast --pgdata "$PGDATA" --max-rate=1024M --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
     else
-        pg_basebackup -Xs -c fast --no-password --max-rate=1024M --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST"
+        "$BASEBACKUP" -Xs -c fast --no-password --max-rate=1024M --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST"
     fi
     touch /var/pv/data/standby.signal
 else
@@ -158,7 +159,16 @@ else
     echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
 fi
 
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 
 if [ "$STANDBY" == "hot" ]; then
     echo "hot_standby = on" >>/tmp/postgresql.conf

--- a/role_scripts/15/standby/run.sh
+++ b/role_scripts/15/standby/run.sh
@@ -168,6 +168,7 @@ echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
     [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
     [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
     echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
 fi
 

--- a/role_scripts/15/standby/warm_stanby.sh
+++ b/role_scripts/15/standby/warm_stanby.sh
@@ -47,6 +47,7 @@ echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
     [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
     [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
     echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
 fi
 

--- a/role_scripts/15/standby/warm_stanby.sh
+++ b/role_scripts/15/standby/warm_stanby.sh
@@ -39,7 +39,16 @@ echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
 
 echo "hot_standby = off" >>/tmp/postgresql.conf
 
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 
 if [[ "$STREAMING" == "synchronous" ]]; then
     # setup synchronous streaming replication

--- a/role_scripts/16/primary/start.sh
+++ b/role_scripts/16/primary/start.sh
@@ -210,6 +210,22 @@ SQL
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || tde_bootstrap_fatal "failed to set global principal key '${TDE_KEY_NAME}'"
+
+        # Set a server-wide DEFAULT principal key so databases created later inherit
+        # encryption. pg_tde stores the principal key per database OID and CREATE
+        # DATABASE does NOT copy it (a key set in template1 is not carried to its
+        # clones), so without a server default the first encrypted CREATE TABLE in a
+        # newly created database fails "principal key not configured" under a
+        # cluster-wide default_table_access_method = tde_heap. The default key is a
+        # global-provider feature; the file keyring (standalone, database-scoped) has
+        # no server default, so this applies to the vault/kmip providers only. Create
+        # precedes set, and the set is strict like the principal-key set above.
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
+            || echo "pg_tde: create default key returned non-zero (may already exist), continuing to set"
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_default_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
+            || tde_bootstrap_fatal "failed to set default principal key '${TDE_KEY_NAME}-default'"
     fi
 
     # WAL encryption is global-only: the file keyring is a database-scoped

--- a/role_scripts/16/primary/start.sh
+++ b/role_scripts/16/primary/start.sh
@@ -155,6 +155,18 @@ if [[ "${TDE_ENABLED:-false}" == "true" && "${BOOTSTRAP}" == "true" ]]; then
     # post-bootstrap config that carries pg_tde.cipher is not loaded yet, so without
     # this the principal key would be created (and validated) at the wrong length.
     export PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}"
+    # tde_bootstrap_fatal aborts a failed first-time TDE bootstrap loudly. This runs
+    # only during initial initialization (BOOTSTRAP=true), so there is no user data
+    # yet; wipe the half-initialized data dir and exit non-zero. That forces a full
+    # re-bootstrap on the next start instead of falling through to a keyless boot
+    # (which would silently disable encryption). The pod crash-loops visibly until
+    # the key provider is reachable.
+    tde_bootstrap_fatal() {
+        echo "pg_tde FATAL: $1"
+        pg_ctl -D "$PGDATA" -m immediate -w stop || true
+        rm -rf "${PGDATA:?}"/* || true
+        exit 1
+    }
     # Enable the extension in the default databases. template1 makes it the
     # default for future databases.
     for TDE_DB in template1 "$POSTGRES_DB"; do
@@ -190,14 +202,14 @@ SQL
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
-            || { echo "pg_tde FATAL: failed to set database principal key '${TDE_KEY_NAME}'"; exit 1; }
+            || tde_bootstrap_fatal "failed to set database principal key '${TDE_KEY_NAME}'"
     else
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
-            || { echo "pg_tde FATAL: failed to set global principal key '${TDE_KEY_NAME}'"; exit 1; }
+            || tde_bootstrap_fatal "failed to set global principal key '${TDE_KEY_NAME}'"
     fi
 
     # If WAL encryption is requested, create + set the server (WAL) key too (global only).
@@ -207,7 +219,7 @@ SQL
             || echo "pg_tde: create WAL server key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_server_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
-            || { echo "pg_tde FATAL: failed to set WAL server key '${TDE_KEY_NAME}-wal'"; exit 1; }
+            || tde_bootstrap_fatal "failed to set WAL server key '${TDE_KEY_NAME}-wal'"
     fi
 fi
 

--- a/role_scripts/16/primary/start.sh
+++ b/role_scripts/16/primary/start.sh
@@ -212,6 +212,13 @@ SQL
             || tde_bootstrap_fatal "failed to set global principal key '${TDE_KEY_NAME}'"
     fi
 
+    # WAL encryption is global-only: the file keyring is a database-scoped
+    # provider and cannot back a server key. The operator webhook already rejects
+    # this combination, so this is a fail-closed backstop with a clear message
+    # (instead of a swallowed error that crash-loops on the misleading set-key fatal).
+    if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" && "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
+        tde_bootstrap_fatal "WAL encryption requires a global (vault or kmip) key provider; the file keyring cannot back WAL encryption"
+    fi
     # If WAL encryption is requested, create + set the server (WAL) key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \

--- a/role_scripts/16/primary/start.sh
+++ b/role_scripts/16/primary/start.sh
@@ -43,7 +43,11 @@ else
     echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
 fi
 
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 
 if [[ "${SSL:-0}" == "ON" ]]; then
     echo "ssl =on" >>/tmp/postgresql.conf
@@ -142,6 +146,45 @@ echo
 
 psql+=(--username "$POSTGRES_USER" --dbname "$POSTGRES_DB")
 echo
+
+# pg_tde principal-key bootstrap. Runs once on first initialization, after the
+# database and superuser exist and before any encrypted table or the
+# default_table_access_method flip can be used. Idempotent on retries.
+if [[ "${TDE_ENABLED:-false}" == "true" && "${BOOTSTRAP}" == "true" ]]; then
+    # Enable the extension in the default databases. template1 makes it the
+    # default for future databases.
+    for TDE_DB in template1 "$POSTGRES_DB"; do
+        psql -U postgres -d "$TDE_DB" -v ON_ERROR_STOP=1 <<SQL
+CREATE EXTENSION IF NOT EXISTS ${TDE_EXTENSION:-pg_tde};
+SQL
+    done
+
+    # Register the key provider (global preferred; file is standalone only).
+    case "${TDE_PROVIDER_KIND:-}" in
+        vault)
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_add_global_key_provider_vault_v2('${TDE_PROVIDER_NAME}','${TDE_VAULT_ADDR}','${TDE_VAULT_MOUNT}','${TDE_VAULT_TOKEN_PATH}','${TDE_VAULT_CA_PATH}');" || true
+            ;;
+        kmip)
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_add_global_key_provider_kmip('${TDE_PROVIDER_NAME}','${TDE_KMIP_ADDR}',${TDE_KMIP_PORT},'${TDE_KMIP_CLIENT_CERT_PATH}','${TDE_KMIP_CLIENT_KEY_PATH}','${TDE_KMIP_CA_PATH}');" || true
+            ;;
+        file)
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_add_database_key_provider_file('${TDE_PROVIDER_NAME}','${TDE_FILE_PATH}');" || true
+            ;;
+    esac
+
+    # Set the per-database principal key.
+    psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+
+    # If WAL encryption is requested, set the server key too (global only).
+    if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_server_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" || true
+    fi
+fi
 
 if [[ "$BOOTSTRAP" == "true" ]];then
   # initialize database
@@ -270,6 +313,14 @@ fi
 mv /tmp/pg_hba.conf "$PGDATA/pg_hba.conf"
 
 touch /tmp/postgresql.conf
+# pg_tde runtime GUCs. Authored in the post-bootstrap rewrite, after the
+# extension and principal key exist, so default_table_access_method is safe.
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 if [ "$STANDBY" == "hot" ]; then
     echo "hot_standby = on" >>/tmp/postgresql.conf
 else

--- a/role_scripts/16/primary/start.sh
+++ b/role_scripts/16/primary/start.sh
@@ -215,17 +215,22 @@ SQL
         # encryption. pg_tde stores the principal key per database OID and CREATE
         # DATABASE does NOT copy it (a key set in template1 is not carried to its
         # clones), so without a server default the first encrypted CREATE TABLE in a
-        # newly created database fails "principal key not configured" under a
-        # cluster-wide default_table_access_method = tde_heap. The default key is a
-        # global-provider feature; the file keyring (standalone, database-scoped) has
-        # no server default, so this applies to the vault/kmip providers only. Create
-        # precedes set, and the set is strict like the principal-key set above.
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
-            || echo "pg_tde: create default key returned non-zero (may already exist), continuing to set"
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_set_default_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
-            || tde_bootstrap_fatal "failed to set default principal key '${TDE_KEY_NAME}-default'"
+        # newly created database fails "principal key not configured". This only
+        # matters when new tables are encrypted by default or enforced cluster-wide,
+        # so gate it on TDE_DEFAULT_AM/TDE_ENFORCE (mirroring how the WAL block below
+        # gates on TDE_ENCRYPT_WAL): a plain opt-in-per-table cluster does not need a
+        # server default and should not take the strict-set crash-loop risk for it.
+        # The default key is a global-provider feature; the file keyring (standalone,
+        # database-scoped) has no server default, so this applies to vault/kmip only.
+        # Create precedes set, and the set is strict like the principal-key set above.
+        if [[ "${TDE_DEFAULT_AM:-false}" == "true" || "${TDE_ENFORCE:-false}" == "true" ]]; then
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
+                || echo "pg_tde: create default key returned non-zero (may already exist), continuing to set"
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_set_default_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
+                || tde_bootstrap_fatal "failed to set default principal key '${TDE_KEY_NAME}-default'"
+        fi
     fi
 
     # WAL encryption is global-only: the file keyring is a database-scoped

--- a/role_scripts/16/primary/start.sh
+++ b/role_scripts/16/primary/start.sh
@@ -151,6 +151,10 @@ echo
 # database and superuser exist and before any encrypted table or the
 # default_table_access_method flip can be used. Idempotent on retries.
 if [[ "${TDE_ENABLED:-false}" == "true" && "${BOOTSTRAP}" == "true" ]]; then
+    # Run every pg_tde key operation in this block at the configured cipher. The
+    # post-bootstrap config that carries pg_tde.cipher is not loaded yet, so without
+    # this the principal key would be created (and validated) at the wrong length.
+    export PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}"
     # Enable the extension in the default databases. template1 makes it the
     # default for future databases.
     for TDE_DB in template1 "$POSTGRES_DB"; do
@@ -181,14 +185,14 @@ SQL
     # Key setup is strict: a failure fails the bootstrap loudly rather than booting
     # with no principal key, which would silently break encrypted-table creation.
     if [[ "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
-        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || { echo "pg_tde FATAL: failed to set database principal key '${TDE_KEY_NAME}'"; exit 1; }
     else
-        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
@@ -198,7 +202,7 @@ SQL
 
     # If WAL encryption is requested, create + set the server (WAL) key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
-        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create WAL server key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
@@ -206,6 +210,8 @@ SQL
             || { echo "pg_tde FATAL: failed to set WAL server key '${TDE_KEY_NAME}-wal'"; exit 1; }
     fi
 fi
+
+unset PGOPTIONS
 
 if [[ "$BOOTSTRAP" == "true" ]];then
   # initialize database

--- a/role_scripts/16/primary/start.sh
+++ b/role_scripts/16/primary/start.sh
@@ -181,14 +181,14 @@ SQL
     # Key setup is strict: a failure fails the bootstrap loudly rather than booting
     # with no principal key, which would silently break encrypted-table creation.
     if [[ "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || { echo "pg_tde FATAL: failed to set database principal key '${TDE_KEY_NAME}'"; exit 1; }
     else
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
@@ -198,7 +198,7 @@ SQL
 
     # If WAL encryption is requested, create + set the server (WAL) key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create WAL server key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \

--- a/role_scripts/16/primary/start.sh
+++ b/role_scripts/16/primary/start.sh
@@ -175,9 +175,15 @@ SQL
             ;;
     esac
 
-    # Set the per-database principal key.
-    psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-        "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+    # Set the per-database principal key with the setter that matches the
+    # provider scope: file providers are database-scoped, vault/kmip are global.
+    if [[ "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+    else
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+    fi
 
     # If WAL encryption is requested, set the server key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then

--- a/role_scripts/16/primary/start.sh
+++ b/role_scripts/16/primary/start.sh
@@ -178,8 +178,18 @@ SQL
     # Register the key provider (global preferred; file is standalone only).
     case "${TDE_PROVIDER_KIND:-}" in
         vault)
-            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-                "SELECT pg_tde_add_global_key_provider_vault_v2('${TDE_PROVIDER_NAME}','${TDE_VAULT_ADDR}','${TDE_VAULT_MOUNT}','${TDE_VAULT_TOKEN_PATH}','${TDE_VAULT_CA_PATH}');" || true
+            # pg_tde_add_global_key_provider_vault_v2 has a 5-arg form and a 6-arg
+            # form that also takes a Vault Enterprise namespace. Pass the namespace
+            # (spec.tde.keyProvider.vault.namespace -> TDE_VAULT_NAMESPACE) only when
+            # it is set, so the common namespace-less case keeps the 5-arg form; the
+            # namespace was otherwise accepted in the CRD but silently dropped here.
+            if [[ -n "${TDE_VAULT_NAMESPACE:-}" ]]; then
+                psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                    "SELECT pg_tde_add_global_key_provider_vault_v2('${TDE_PROVIDER_NAME}','${TDE_VAULT_ADDR}','${TDE_VAULT_MOUNT}','${TDE_VAULT_TOKEN_PATH}','${TDE_VAULT_CA_PATH}','${TDE_VAULT_NAMESPACE}');" || true
+            else
+                psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                    "SELECT pg_tde_add_global_key_provider_vault_v2('${TDE_PROVIDER_NAME}','${TDE_VAULT_ADDR}','${TDE_VAULT_MOUNT}','${TDE_VAULT_TOKEN_PATH}','${TDE_VAULT_CA_PATH}');" || true
+            fi
             ;;
         kmip)
             psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \

--- a/role_scripts/16/primary/start.sh
+++ b/role_scripts/16/primary/start.sh
@@ -175,20 +175,35 @@ SQL
             ;;
     esac
 
-    # Set the per-database principal key with the setter that matches the
-    # provider scope: file providers are database-scoped, vault/kmip are global.
+    # Create then set the per-database principal key. pg_tde requires the key to
+    # exist before it can be set as principal, so create precedes set. The setter
+    # matches the provider scope (file is database-scoped, vault/kmip are global).
+    # Key setup is strict: a failure fails the bootstrap loudly rather than booting
+    # with no principal key, which would silently break encrypted-table creation.
     if [[ "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+            "SELECT pg_tde_create_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
+            || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
+            || { echo "pg_tde FATAL: failed to set database principal key '${TDE_KEY_NAME}'"; exit 1; }
     else
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+            "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
+            || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
+            || { echo "pg_tde FATAL: failed to set global principal key '${TDE_KEY_NAME}'"; exit 1; }
     fi
 
-    # If WAL encryption is requested, set the server key too (global only).
+    # If WAL encryption is requested, create + set the server (WAL) key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_set_server_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" || true
+            "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
+            || echo "pg_tde: create WAL server key returned non-zero (may already exist), continuing to set"
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_server_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
+            || { echo "pg_tde FATAL: failed to set WAL server key '${TDE_KEY_NAME}-wal'"; exit 1; }
     fi
 fi
 

--- a/role_scripts/16/standby/ha_backup_job.sh
+++ b/role_scripts/16/standby/ha_backup_job.sh
@@ -102,6 +102,7 @@ echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
     [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
     [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
     echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
 fi
 

--- a/role_scripts/16/standby/ha_backup_job.sh
+++ b/role_scripts/16/standby/ha_backup_job.sh
@@ -63,6 +63,7 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     chmod 0700 "$PGDATA"
     BASEBACKUP=pg_basebackup
     [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
+    echo "pg_tde: seeding standby with '$BASEBACKUP' (TDE_ENABLED=${TDE_ENABLED:-false})"
     if [[ "${SSL:-0}" == "ON" ]]; then
         "$BASEBACKUP" -X fetch --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
     else

--- a/role_scripts/16/standby/ha_backup_job.sh
+++ b/role_scripts/16/standby/ha_backup_job.sh
@@ -61,10 +61,12 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     mkdir -p "$PGDATA"
     rm -rf "$PGDATA"/*
     chmod 0700 "$PGDATA"
+    BASEBACKUP=pg_basebackup
+    [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
     if [[ "${SSL:-0}" == "ON" ]]; then
-        pg_basebackup -X fetch --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
+        "$BASEBACKUP" -X fetch --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
     else
-        pg_basebackup -X fetch --no-password --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST"
+        "$BASEBACKUP" -X fetch --no-password --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST"
     fi
 fi
 
@@ -91,7 +93,16 @@ echo "wal_log_hints = on" >>/tmp/postgresql.conf
 echo "archive_mode = always" >>/tmp/postgresql.conf
 echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
 
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 
 if [ "$STANDBY" == "hot" ]; then
     echo "hot_standby = on" >>/tmp/postgresql.conf

--- a/role_scripts/16/standby/remote-replica.sh
+++ b/role_scripts/16/standby/remote-replica.sh
@@ -110,6 +110,7 @@ echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
     [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
     [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
     echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
 fi
 

--- a/role_scripts/16/standby/remote-replica.sh
+++ b/role_scripts/16/standby/remote-replica.sh
@@ -69,10 +69,12 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     mkdir -p "$PGDATA"
     rm -rf "$PGDATA"/*
     chmod 0700 "$PGDATA"
+    BASEBACKUP=pg_basebackup
+    [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
     if [[ "${SOURCE_SSL:-0}" == "ON" ]]; then
-        pg_basebackup -X fetch --pgdata "$PGDATA" --username=$PRIMARY_USER_NAME --progress --host="$PRIMARY_HOST" -d "sslmode=$SOURCE_SSL_MODE sslrootcert=/tls/certs/remote/ca.crt sslcert=/tls/certs/remote/client.crt sslkey=/tls/certs/remote/client.key"
+        "$BASEBACKUP" -X fetch --pgdata "$PGDATA" --username=$PRIMARY_USER_NAME --progress --host="$PRIMARY_HOST" -d "sslmode=$SOURCE_SSL_MODE sslrootcert=/tls/certs/remote/ca.crt sslcert=/tls/certs/remote/client.crt sslkey=/tls/certs/remote/client.key"
     else
-        pg_basebackup -X fetch --no-password --pgdata "$PGDATA" --username=$PRIMARY_USER_NAME --progress --host="$PRIMARY_HOST"
+        "$BASEBACKUP" -X fetch --no-password --pgdata "$PGDATA" --username=$PRIMARY_USER_NAME --progress --host="$PRIMARY_HOST"
     fi
 fi
 
@@ -99,7 +101,16 @@ echo "wal_log_hints = on" >>/tmp/postgresql.conf
 echo "archive_mode = always" >>/tmp/postgresql.conf
 echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
 
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 
 if [ "$STANDBY" == "hot" ]; then
     echo "hot_standby = on" >>/tmp/postgresql.conf

--- a/role_scripts/16/standby/remote-replica.sh
+++ b/role_scripts/16/standby/remote-replica.sh
@@ -71,6 +71,7 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     chmod 0700 "$PGDATA"
     BASEBACKUP=pg_basebackup
     [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
+    echo "pg_tde: seeding standby with '$BASEBACKUP' (TDE_ENABLED=${TDE_ENABLED:-false})"
     if [[ "${SOURCE_SSL:-0}" == "ON" ]]; then
         "$BASEBACKUP" -X fetch --pgdata "$PGDATA" --username=$PRIMARY_USER_NAME --progress --host="$PRIMARY_HOST" -d "sslmode=$SOURCE_SSL_MODE sslrootcert=/tls/certs/remote/ca.crt sslcert=/tls/certs/remote/client.crt sslkey=/tls/certs/remote/client.key"
     else

--- a/role_scripts/16/standby/run.sh
+++ b/role_scripts/16/standby/run.sh
@@ -169,6 +169,7 @@ echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
     [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
     [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
     echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
 fi
 

--- a/role_scripts/16/standby/run.sh
+++ b/role_scripts/16/standby/run.sh
@@ -116,17 +116,17 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     mkdir -p "$PGDATA"
     rm -rf "$PGDATA"/*
     chmod 0700 "$PGDATA"
+    BASEBACKUP=pg_basebackup
+    [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
     if [[ "${SSL:-0}" == "ON" ]]; then
-        pg_basebackup -Xs -c fast --pgdata "$PGDATA" --max-rate=1024M --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
+        "$BASEBACKUP" -Xs -c fast --pgdata "$PGDATA" --max-rate=1024M --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
     else
-        pg_basebackup -Xs -c fast --no-password --max-rate=1024M --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST"
+        "$BASEBACKUP" -Xs -c fast --no-password --max-rate=1024M --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST"
     fi
     touch /var/pv/data/standby.signal
 else
     /run_scripts/role/warm_stanby.sh
 fi
-
-
 
 # setup postgresql.conf
 touch /tmp/postgresql.conf
@@ -160,7 +160,16 @@ else
     echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
 fi
 
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 
 if [ "$STANDBY" == "hot" ]; then
     echo "hot_standby = on" >>/tmp/postgresql.conf

--- a/role_scripts/16/standby/run.sh
+++ b/role_scripts/16/standby/run.sh
@@ -118,6 +118,7 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     chmod 0700 "$PGDATA"
     BASEBACKUP=pg_basebackup
     [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
+    echo "pg_tde: seeding standby with '$BASEBACKUP' (TDE_ENABLED=${TDE_ENABLED:-false})"
     if [[ "${SSL:-0}" == "ON" ]]; then
         "$BASEBACKUP" -Xs -c fast --pgdata "$PGDATA" --max-rate=1024M --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
     else

--- a/role_scripts/16/standby/warm_stanby.sh
+++ b/role_scripts/16/standby/warm_stanby.sh
@@ -47,6 +47,7 @@ echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
     [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
     [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
     echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
 fi
 

--- a/role_scripts/16/standby/warm_stanby.sh
+++ b/role_scripts/16/standby/warm_stanby.sh
@@ -39,7 +39,16 @@ echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
 
 echo "hot_standby = off" >>/tmp/postgresql.conf
 
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 
 if [[ "$STREAMING" == "synchronous" ]]; then
     # setup synchronous streaming replication

--- a/role_scripts/17/primary/start.sh
+++ b/role_scripts/17/primary/start.sh
@@ -183,8 +183,18 @@ SQL
     # Register the key provider (global preferred; file is standalone only).
     case "${TDE_PROVIDER_KIND:-}" in
         vault)
-            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-                "SELECT pg_tde_add_global_key_provider_vault_v2('${TDE_PROVIDER_NAME}','${TDE_VAULT_ADDR}','${TDE_VAULT_MOUNT}','${TDE_VAULT_TOKEN_PATH}','${TDE_VAULT_CA_PATH}');" || true
+            # pg_tde_add_global_key_provider_vault_v2 has a 5-arg form and a 6-arg
+            # form that also takes a Vault Enterprise namespace. Pass the namespace
+            # (spec.tde.keyProvider.vault.namespace -> TDE_VAULT_NAMESPACE) only when
+            # it is set, so the common namespace-less case keeps the 5-arg form; the
+            # namespace was otherwise accepted in the CRD but silently dropped here.
+            if [[ -n "${TDE_VAULT_NAMESPACE:-}" ]]; then
+                psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                    "SELECT pg_tde_add_global_key_provider_vault_v2('${TDE_PROVIDER_NAME}','${TDE_VAULT_ADDR}','${TDE_VAULT_MOUNT}','${TDE_VAULT_TOKEN_PATH}','${TDE_VAULT_CA_PATH}','${TDE_VAULT_NAMESPACE}');" || true
+            else
+                psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                    "SELECT pg_tde_add_global_key_provider_vault_v2('${TDE_PROVIDER_NAME}','${TDE_VAULT_ADDR}','${TDE_VAULT_MOUNT}','${TDE_VAULT_TOKEN_PATH}','${TDE_VAULT_CA_PATH}');" || true
+            fi
             ;;
         kmip)
             psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \

--- a/role_scripts/17/primary/start.sh
+++ b/role_scripts/17/primary/start.sh
@@ -215,6 +215,22 @@ SQL
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || tde_bootstrap_fatal "failed to set global principal key '${TDE_KEY_NAME}'"
+
+        # Set a server-wide DEFAULT principal key so databases created later inherit
+        # encryption. pg_tde stores the principal key per database OID and CREATE
+        # DATABASE does NOT copy it (a key set in template1 is not carried to its
+        # clones), so without a server default the first encrypted CREATE TABLE in a
+        # newly created database fails "principal key not configured" under a
+        # cluster-wide default_table_access_method = tde_heap. The default key is a
+        # global-provider feature; the file keyring (standalone, database-scoped) has
+        # no server default, so this applies to the vault/kmip providers only. Create
+        # precedes set, and the set is strict like the principal-key set above.
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
+            || echo "pg_tde: create default key returned non-zero (may already exist), continuing to set"
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_default_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
+            || tde_bootstrap_fatal "failed to set default principal key '${TDE_KEY_NAME}-default'"
     fi
 
     # WAL encryption is global-only: the file keyring is a database-scoped

--- a/role_scripts/17/primary/start.sh
+++ b/role_scripts/17/primary/start.sh
@@ -217,6 +217,13 @@ SQL
             || tde_bootstrap_fatal "failed to set global principal key '${TDE_KEY_NAME}'"
     fi
 
+    # WAL encryption is global-only: the file keyring is a database-scoped
+    # provider and cannot back a server key. The operator webhook already rejects
+    # this combination, so this is a fail-closed backstop with a clear message
+    # (instead of a swallowed error that crash-loops on the misleading set-key fatal).
+    if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" && "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
+        tde_bootstrap_fatal "WAL encryption requires a global (vault or kmip) key provider; the file keyring cannot back WAL encryption"
+    fi
     # If WAL encryption is requested, create + set the server (WAL) key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \

--- a/role_scripts/17/primary/start.sh
+++ b/role_scripts/17/primary/start.sh
@@ -186,14 +186,14 @@ SQL
     # Key setup is strict: a failure fails the bootstrap loudly rather than booting
     # with no principal key, which would silently break encrypted-table creation.
     if [[ "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || { echo "pg_tde FATAL: failed to set database principal key '${TDE_KEY_NAME}'"; exit 1; }
     else
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
@@ -203,7 +203,7 @@ SQL
 
     # If WAL encryption is requested, create + set the server (WAL) key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create WAL server key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \

--- a/role_scripts/17/primary/start.sh
+++ b/role_scripts/17/primary/start.sh
@@ -44,7 +44,11 @@ else
     echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
 fi
 
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 
 if [[ "${SSL:-0}" == "ON" ]]; then
     echo "ssl =on" >>/tmp/postgresql.conf
@@ -147,6 +151,45 @@ echo
 
 psql+=(--username "$POSTGRES_USER" --dbname "$POSTGRES_DB")
 echo
+
+# pg_tde principal-key bootstrap. Runs once on first initialization, after the
+# database and superuser exist and before any encrypted table or the
+# default_table_access_method flip can be used. Idempotent on retries.
+if [[ "${TDE_ENABLED:-false}" == "true" && "${BOOTSTRAP}" == "true" ]]; then
+    # Enable the extension in the default databases. template1 makes it the
+    # default for future databases.
+    for TDE_DB in template1 "$POSTGRES_DB"; do
+        psql -U postgres -d "$TDE_DB" -v ON_ERROR_STOP=1 <<SQL
+CREATE EXTENSION IF NOT EXISTS ${TDE_EXTENSION:-pg_tde};
+SQL
+    done
+
+    # Register the key provider (global preferred; file is standalone only).
+    case "${TDE_PROVIDER_KIND:-}" in
+        vault)
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_add_global_key_provider_vault_v2('${TDE_PROVIDER_NAME}','${TDE_VAULT_ADDR}','${TDE_VAULT_MOUNT}','${TDE_VAULT_TOKEN_PATH}','${TDE_VAULT_CA_PATH}');" || true
+            ;;
+        kmip)
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_add_global_key_provider_kmip('${TDE_PROVIDER_NAME}','${TDE_KMIP_ADDR}',${TDE_KMIP_PORT},'${TDE_KMIP_CLIENT_CERT_PATH}','${TDE_KMIP_CLIENT_KEY_PATH}','${TDE_KMIP_CA_PATH}');" || true
+            ;;
+        file)
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_add_database_key_provider_file('${TDE_PROVIDER_NAME}','${TDE_FILE_PATH}');" || true
+            ;;
+    esac
+
+    # Set the per-database principal key.
+    psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+
+    # If WAL encryption is requested, set the server key too (global only).
+    if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_server_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" || true
+    fi
+fi
 
 if [[ "$BOOTSTRAP" == "true" ]];then
   # initialize database
@@ -275,6 +318,14 @@ fi
 mv /tmp/pg_hba.conf "$PGDATA/pg_hba.conf"
 
 touch /tmp/postgresql.conf
+# pg_tde runtime GUCs. Authored in the post-bootstrap rewrite, after the
+# extension and principal key exist, so default_table_access_method is safe.
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 if [ "$STANDBY" == "hot" ]; then
     echo "hot_standby = on" >>/tmp/postgresql.conf
 else

--- a/role_scripts/17/primary/start.sh
+++ b/role_scripts/17/primary/start.sh
@@ -160,6 +160,18 @@ if [[ "${TDE_ENABLED:-false}" == "true" && "${BOOTSTRAP}" == "true" ]]; then
     # post-bootstrap config that carries pg_tde.cipher is not loaded yet, so without
     # this the principal key would be created (and validated) at the wrong length.
     export PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}"
+    # tde_bootstrap_fatal aborts a failed first-time TDE bootstrap loudly. This runs
+    # only during initial initialization (BOOTSTRAP=true), so there is no user data
+    # yet; wipe the half-initialized data dir and exit non-zero. That forces a full
+    # re-bootstrap on the next start instead of falling through to a keyless boot
+    # (which would silently disable encryption). The pod crash-loops visibly until
+    # the key provider is reachable.
+    tde_bootstrap_fatal() {
+        echo "pg_tde FATAL: $1"
+        pg_ctl -D "$PGDATA" -m immediate -w stop || true
+        rm -rf "${PGDATA:?}"/* || true
+        exit 1
+    }
     # Enable the extension in the default databases. template1 makes it the
     # default for future databases.
     for TDE_DB in template1 "$POSTGRES_DB"; do
@@ -195,14 +207,14 @@ SQL
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
-            || { echo "pg_tde FATAL: failed to set database principal key '${TDE_KEY_NAME}'"; exit 1; }
+            || tde_bootstrap_fatal "failed to set database principal key '${TDE_KEY_NAME}'"
     else
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
-            || { echo "pg_tde FATAL: failed to set global principal key '${TDE_KEY_NAME}'"; exit 1; }
+            || tde_bootstrap_fatal "failed to set global principal key '${TDE_KEY_NAME}'"
     fi
 
     # If WAL encryption is requested, create + set the server (WAL) key too (global only).
@@ -212,7 +224,7 @@ SQL
             || echo "pg_tde: create WAL server key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_server_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
-            || { echo "pg_tde FATAL: failed to set WAL server key '${TDE_KEY_NAME}-wal'"; exit 1; }
+            || tde_bootstrap_fatal "failed to set WAL server key '${TDE_KEY_NAME}-wal'"
     fi
 fi
 

--- a/role_scripts/17/primary/start.sh
+++ b/role_scripts/17/primary/start.sh
@@ -180,20 +180,35 @@ SQL
             ;;
     esac
 
-    # Set the per-database principal key with the setter that matches the
-    # provider scope: file providers are database-scoped, vault/kmip are global.
+    # Create then set the per-database principal key. pg_tde requires the key to
+    # exist before it can be set as principal, so create precedes set. The setter
+    # matches the provider scope (file is database-scoped, vault/kmip are global).
+    # Key setup is strict: a failure fails the bootstrap loudly rather than booting
+    # with no principal key, which would silently break encrypted-table creation.
     if [[ "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+            "SELECT pg_tde_create_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
+            || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
+            || { echo "pg_tde FATAL: failed to set database principal key '${TDE_KEY_NAME}'"; exit 1; }
     else
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+            "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
+            || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
+            || { echo "pg_tde FATAL: failed to set global principal key '${TDE_KEY_NAME}'"; exit 1; }
     fi
 
-    # If WAL encryption is requested, set the server key too (global only).
+    # If WAL encryption is requested, create + set the server (WAL) key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_set_server_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" || true
+            "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
+            || echo "pg_tde: create WAL server key returned non-zero (may already exist), continuing to set"
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_server_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
+            || { echo "pg_tde FATAL: failed to set WAL server key '${TDE_KEY_NAME}-wal'"; exit 1; }
     fi
 fi
 

--- a/role_scripts/17/primary/start.sh
+++ b/role_scripts/17/primary/start.sh
@@ -180,9 +180,15 @@ SQL
             ;;
     esac
 
-    # Set the per-database principal key.
-    psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-        "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+    # Set the per-database principal key with the setter that matches the
+    # provider scope: file providers are database-scoped, vault/kmip are global.
+    if [[ "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+    else
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+    fi
 
     # If WAL encryption is requested, set the server key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then

--- a/role_scripts/17/primary/start.sh
+++ b/role_scripts/17/primary/start.sh
@@ -156,6 +156,10 @@ echo
 # database and superuser exist and before any encrypted table or the
 # default_table_access_method flip can be used. Idempotent on retries.
 if [[ "${TDE_ENABLED:-false}" == "true" && "${BOOTSTRAP}" == "true" ]]; then
+    # Run every pg_tde key operation in this block at the configured cipher. The
+    # post-bootstrap config that carries pg_tde.cipher is not loaded yet, so without
+    # this the principal key would be created (and validated) at the wrong length.
+    export PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}"
     # Enable the extension in the default databases. template1 makes it the
     # default for future databases.
     for TDE_DB in template1 "$POSTGRES_DB"; do
@@ -186,14 +190,14 @@ SQL
     # Key setup is strict: a failure fails the bootstrap loudly rather than booting
     # with no principal key, which would silently break encrypted-table creation.
     if [[ "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
-        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || { echo "pg_tde FATAL: failed to set database principal key '${TDE_KEY_NAME}'"; exit 1; }
     else
-        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
@@ -203,7 +207,7 @@ SQL
 
     # If WAL encryption is requested, create + set the server (WAL) key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
-        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create WAL server key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
@@ -211,6 +215,8 @@ SQL
             || { echo "pg_tde FATAL: failed to set WAL server key '${TDE_KEY_NAME}-wal'"; exit 1; }
     fi
 fi
+
+unset PGOPTIONS
 
 if [[ "$BOOTSTRAP" == "true" ]];then
   # initialize database

--- a/role_scripts/17/primary/start.sh
+++ b/role_scripts/17/primary/start.sh
@@ -220,17 +220,22 @@ SQL
         # encryption. pg_tde stores the principal key per database OID and CREATE
         # DATABASE does NOT copy it (a key set in template1 is not carried to its
         # clones), so without a server default the first encrypted CREATE TABLE in a
-        # newly created database fails "principal key not configured" under a
-        # cluster-wide default_table_access_method = tde_heap. The default key is a
-        # global-provider feature; the file keyring (standalone, database-scoped) has
-        # no server default, so this applies to the vault/kmip providers only. Create
-        # precedes set, and the set is strict like the principal-key set above.
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
-            || echo "pg_tde: create default key returned non-zero (may already exist), continuing to set"
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_set_default_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
-            || tde_bootstrap_fatal "failed to set default principal key '${TDE_KEY_NAME}-default'"
+        # newly created database fails "principal key not configured". This only
+        # matters when new tables are encrypted by default or enforced cluster-wide,
+        # so gate it on TDE_DEFAULT_AM/TDE_ENFORCE (mirroring how the WAL block below
+        # gates on TDE_ENCRYPT_WAL): a plain opt-in-per-table cluster does not need a
+        # server default and should not take the strict-set crash-loop risk for it.
+        # The default key is a global-provider feature; the file keyring (standalone,
+        # database-scoped) has no server default, so this applies to vault/kmip only.
+        # Create precedes set, and the set is strict like the principal-key set above.
+        if [[ "${TDE_DEFAULT_AM:-false}" == "true" || "${TDE_ENFORCE:-false}" == "true" ]]; then
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
+                || echo "pg_tde: create default key returned non-zero (may already exist), continuing to set"
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_set_default_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
+                || tde_bootstrap_fatal "failed to set default principal key '${TDE_KEY_NAME}-default'"
+        fi
     fi
 
     # WAL encryption is global-only: the file keyring is a database-scoped

--- a/role_scripts/17/standby/ha_backup_job.sh
+++ b/role_scripts/17/standby/ha_backup_job.sh
@@ -102,6 +102,7 @@ echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
     [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
     [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
     echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
 fi
 

--- a/role_scripts/17/standby/ha_backup_job.sh
+++ b/role_scripts/17/standby/ha_backup_job.sh
@@ -63,6 +63,7 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     chmod 0700 "$PGDATA"
     BASEBACKUP=pg_basebackup
     [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
+    echo "pg_tde: seeding standby with '$BASEBACKUP' (TDE_ENABLED=${TDE_ENABLED:-false})"
     if [[ "${SSL:-0}" == "ON" ]]; then
         "$BASEBACKUP" -X fetch --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
     else

--- a/role_scripts/17/standby/ha_backup_job.sh
+++ b/role_scripts/17/standby/ha_backup_job.sh
@@ -61,10 +61,12 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     mkdir -p "$PGDATA"
     rm -rf "$PGDATA"/*
     chmod 0700 "$PGDATA"
+    BASEBACKUP=pg_basebackup
+    [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
     if [[ "${SSL:-0}" == "ON" ]]; then
-        pg_basebackup -X fetch --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
+        "$BASEBACKUP" -X fetch --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
     else
-        pg_basebackup -X fetch --no-password --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST"
+        "$BASEBACKUP" -X fetch --no-password --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST"
     fi
 fi
 
@@ -91,7 +93,16 @@ echo "wal_log_hints = on" >>/tmp/postgresql.conf
 echo "archive_mode = always" >>/tmp/postgresql.conf
 echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
 
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 
 if [ "$STANDBY" == "hot" ]; then
     echo "hot_standby = on" >>/tmp/postgresql.conf

--- a/role_scripts/17/standby/remote-replica.sh
+++ b/role_scripts/17/standby/remote-replica.sh
@@ -110,6 +110,7 @@ echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
     [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
     [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
     echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
 fi
 

--- a/role_scripts/17/standby/remote-replica.sh
+++ b/role_scripts/17/standby/remote-replica.sh
@@ -69,10 +69,12 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     mkdir -p "$PGDATA"
     rm -rf "$PGDATA"/*
     chmod 0700 "$PGDATA"
+    BASEBACKUP=pg_basebackup
+    [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
     if [[ "${SOURCE_SSL:-0}" == "ON" ]]; then
-        pg_basebackup -X fetch --pgdata "$PGDATA" --username=$PRIMARY_USER_NAME --progress --host="$PRIMARY_HOST" -d "sslmode=$SOURCE_SSL_MODE sslrootcert=/tls/certs/remote/ca.crt sslcert=/tls/certs/remote/client.crt sslkey=/tls/certs/remote/client.key"
+        "$BASEBACKUP" -X fetch --pgdata "$PGDATA" --username=$PRIMARY_USER_NAME --progress --host="$PRIMARY_HOST" -d "sslmode=$SOURCE_SSL_MODE sslrootcert=/tls/certs/remote/ca.crt sslcert=/tls/certs/remote/client.crt sslkey=/tls/certs/remote/client.key"
     else
-        pg_basebackup -X fetch --no-password --pgdata "$PGDATA" --username=$PRIMARY_USER_NAME --progress --host="$PRIMARY_HOST"
+        "$BASEBACKUP" -X fetch --no-password --pgdata "$PGDATA" --username=$PRIMARY_USER_NAME --progress --host="$PRIMARY_HOST"
     fi
 fi
 
@@ -99,7 +101,16 @@ echo "wal_log_hints = on" >>/tmp/postgresql.conf
 echo "archive_mode = always" >>/tmp/postgresql.conf
 echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
 
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 
 if [ "$STANDBY" == "hot" ]; then
     echo "hot_standby = on" >>/tmp/postgresql.conf

--- a/role_scripts/17/standby/remote-replica.sh
+++ b/role_scripts/17/standby/remote-replica.sh
@@ -71,6 +71,7 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     chmod 0700 "$PGDATA"
     BASEBACKUP=pg_basebackup
     [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
+    echo "pg_tde: seeding standby with '$BASEBACKUP' (TDE_ENABLED=${TDE_ENABLED:-false})"
     if [[ "${SOURCE_SSL:-0}" == "ON" ]]; then
         "$BASEBACKUP" -X fetch --pgdata "$PGDATA" --username=$PRIMARY_USER_NAME --progress --host="$PRIMARY_HOST" -d "sslmode=$SOURCE_SSL_MODE sslrootcert=/tls/certs/remote/ca.crt sslcert=/tls/certs/remote/client.crt sslkey=/tls/certs/remote/client.key"
     else

--- a/role_scripts/17/standby/run.sh
+++ b/role_scripts/17/standby/run.sh
@@ -169,6 +169,7 @@ echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
     [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
     [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
     echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
 fi
 

--- a/role_scripts/17/standby/run.sh
+++ b/role_scripts/17/standby/run.sh
@@ -118,6 +118,7 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     chmod 0700 "$PGDATA"
     BASEBACKUP=pg_basebackup
     [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
+    echo "pg_tde: seeding standby with '$BASEBACKUP' (TDE_ENABLED=${TDE_ENABLED:-false})"
     if [[ "${SSL:-0}" == "ON" ]]; then
         "$BASEBACKUP" -Xs -c fast --pgdata "$PGDATA" --max-rate=1024M --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
     else

--- a/role_scripts/17/standby/run.sh
+++ b/role_scripts/17/standby/run.sh
@@ -89,7 +89,6 @@ if [[ "$WAL_LIMIT_POLICY" == "ReplicationSlot" ]]; then
   done
 fi
 
-
 if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     if [[ ! -e "/var/pv/IGNORE_FILESYSTEM_MOUNT_CHECK" ]]; then
       # Robust /var/pv mount availability check before any destructive operation or basebackup
@@ -117,17 +116,17 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     mkdir -p "$PGDATA"
     rm -rf "$PGDATA"/*
     chmod 0700 "$PGDATA"
+    BASEBACKUP=pg_basebackup
+    [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
     if [[ "${SSL:-0}" == "ON" ]]; then
-        pg_basebackup -Xs -c fast --pgdata "$PGDATA" --max-rate=1024M --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
+        "$BASEBACKUP" -Xs -c fast --pgdata "$PGDATA" --max-rate=1024M --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
     else
-        pg_basebackup -Xs -c fast --no-password --max-rate=1024M --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST"
+        "$BASEBACKUP" -Xs -c fast --no-password --max-rate=1024M --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST"
     fi
     touch /var/pv/data/standby.signal
 else
     /run_scripts/role/warm_stanby.sh
 fi
-
-
 
 # setup postgresql.conf
 touch /tmp/postgresql.conf
@@ -161,7 +160,16 @@ else
     echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
 fi
 
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 
 if [ "$STANDBY" == "hot" ]; then
     echo "hot_standby = on" >>/tmp/postgresql.conf

--- a/role_scripts/17/standby/warm_stanby.sh
+++ b/role_scripts/17/standby/warm_stanby.sh
@@ -47,6 +47,7 @@ echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
     [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
     [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
     echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
 fi
 

--- a/role_scripts/17/standby/warm_stanby.sh
+++ b/role_scripts/17/standby/warm_stanby.sh
@@ -39,7 +39,16 @@ echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
 
 echo "hot_standby = off" >>/tmp/postgresql.conf
 
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 
 if [[ "$STREAMING" == "synchronous" ]]; then
     # setup synchronous streaming replication

--- a/role_scripts/18/primary/start.sh
+++ b/role_scripts/18/primary/start.sh
@@ -173,20 +173,35 @@ SQL
             ;;
     esac
 
-    # Set the per-database principal key with the setter that matches the
-    # provider scope: file providers are database-scoped, vault/kmip are global.
+    # Create then set the per-database principal key. pg_tde requires the key to
+    # exist before it can be set as principal, so create precedes set. The setter
+    # matches the provider scope (file is database-scoped, vault/kmip are global).
+    # Key setup is strict: a failure fails the bootstrap loudly rather than booting
+    # with no principal key, which would silently break encrypted-table creation.
     if [[ "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+            "SELECT pg_tde_create_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
+            || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
+            || { echo "pg_tde FATAL: failed to set database principal key '${TDE_KEY_NAME}'"; exit 1; }
     else
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+            "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
+            || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
+            || { echo "pg_tde FATAL: failed to set global principal key '${TDE_KEY_NAME}'"; exit 1; }
     fi
 
-    # If WAL encryption is requested, set the server key too (global only).
+    # If WAL encryption is requested, create + set the server (WAL) key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_set_server_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" || true
+            "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
+            || echo "pg_tde: create WAL server key returned non-zero (may already exist), continuing to set"
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_server_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
+            || { echo "pg_tde FATAL: failed to set WAL server key '${TDE_KEY_NAME}-wal'"; exit 1; }
     fi
 fi
 

--- a/role_scripts/18/primary/start.sh
+++ b/role_scripts/18/primary/start.sh
@@ -210,6 +210,13 @@ SQL
             || tde_bootstrap_fatal "failed to set global principal key '${TDE_KEY_NAME}'"
     fi
 
+    # WAL encryption is global-only: the file keyring is a database-scoped
+    # provider and cannot back a server key. The operator webhook already rejects
+    # this combination, so this is a fail-closed backstop with a clear message
+    # (instead of a swallowed error that crash-loops on the misleading set-key fatal).
+    if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" && "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
+        tde_bootstrap_fatal "WAL encryption requires a global (vault or kmip) key provider; the file keyring cannot back WAL encryption"
+    fi
     # If WAL encryption is requested, create + set the server (WAL) key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \

--- a/role_scripts/18/primary/start.sh
+++ b/role_scripts/18/primary/start.sh
@@ -213,17 +213,22 @@ SQL
         # encryption. pg_tde stores the principal key per database OID and CREATE
         # DATABASE does NOT copy it (a key set in template1 is not carried to its
         # clones), so without a server default the first encrypted CREATE TABLE in a
-        # newly created database fails "principal key not configured" under a
-        # cluster-wide default_table_access_method = tde_heap. The default key is a
-        # global-provider feature; the file keyring (standalone, database-scoped) has
-        # no server default, so this applies to the vault/kmip providers only. Create
-        # precedes set, and the set is strict like the principal-key set above.
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
-            || echo "pg_tde: create default key returned non-zero (may already exist), continuing to set"
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_set_default_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
-            || tde_bootstrap_fatal "failed to set default principal key '${TDE_KEY_NAME}-default'"
+        # newly created database fails "principal key not configured". This only
+        # matters when new tables are encrypted by default or enforced cluster-wide,
+        # so gate it on TDE_DEFAULT_AM/TDE_ENFORCE (mirroring how the WAL block below
+        # gates on TDE_ENCRYPT_WAL): a plain opt-in-per-table cluster does not need a
+        # server default and should not take the strict-set crash-loop risk for it.
+        # The default key is a global-provider feature; the file keyring (standalone,
+        # database-scoped) has no server default, so this applies to vault/kmip only.
+        # Create precedes set, and the set is strict like the principal-key set above.
+        if [[ "${TDE_DEFAULT_AM:-false}" == "true" || "${TDE_ENFORCE:-false}" == "true" ]]; then
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
+                || echo "pg_tde: create default key returned non-zero (may already exist), continuing to set"
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_set_default_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
+                || tde_bootstrap_fatal "failed to set default principal key '${TDE_KEY_NAME}-default'"
+        fi
     fi
 
     # WAL encryption is global-only: the file keyring is a database-scoped

--- a/role_scripts/18/primary/start.sh
+++ b/role_scripts/18/primary/start.sh
@@ -153,6 +153,18 @@ if [[ "${TDE_ENABLED:-false}" == "true" && "${BOOTSTRAP}" == "true" ]]; then
     # post-bootstrap config that carries pg_tde.cipher is not loaded yet, so without
     # this the principal key would be created (and validated) at the wrong length.
     export PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}"
+    # tde_bootstrap_fatal aborts a failed first-time TDE bootstrap loudly. This runs
+    # only during initial initialization (BOOTSTRAP=true), so there is no user data
+    # yet; wipe the half-initialized data dir and exit non-zero. That forces a full
+    # re-bootstrap on the next start instead of falling through to a keyless boot
+    # (which would silently disable encryption). The pod crash-loops visibly until
+    # the key provider is reachable.
+    tde_bootstrap_fatal() {
+        echo "pg_tde FATAL: $1"
+        pg_ctl -D "$PGDATA" -m immediate -w stop || true
+        rm -rf "${PGDATA:?}"/* || true
+        exit 1
+    }
     # Enable the extension in the default databases. template1 makes it the
     # default for future databases.
     for TDE_DB in template1 "$POSTGRES_DB"; do
@@ -188,14 +200,14 @@ SQL
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
-            || { echo "pg_tde FATAL: failed to set database principal key '${TDE_KEY_NAME}'"; exit 1; }
+            || tde_bootstrap_fatal "failed to set database principal key '${TDE_KEY_NAME}'"
     else
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
-            || { echo "pg_tde FATAL: failed to set global principal key '${TDE_KEY_NAME}'"; exit 1; }
+            || tde_bootstrap_fatal "failed to set global principal key '${TDE_KEY_NAME}'"
     fi
 
     # If WAL encryption is requested, create + set the server (WAL) key too (global only).
@@ -205,7 +217,7 @@ SQL
             || echo "pg_tde: create WAL server key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_server_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
-            || { echo "pg_tde FATAL: failed to set WAL server key '${TDE_KEY_NAME}-wal'"; exit 1; }
+            || tde_bootstrap_fatal "failed to set WAL server key '${TDE_KEY_NAME}-wal'"
     fi
 fi
 

--- a/role_scripts/18/primary/start.sh
+++ b/role_scripts/18/primary/start.sh
@@ -149,6 +149,10 @@ echo
 # database and superuser exist and before any encrypted table or the
 # default_table_access_method flip can be used. Idempotent on retries.
 if [[ "${TDE_ENABLED:-false}" == "true" && "${BOOTSTRAP}" == "true" ]]; then
+    # Run every pg_tde key operation in this block at the configured cipher. The
+    # post-bootstrap config that carries pg_tde.cipher is not loaded yet, so without
+    # this the principal key would be created (and validated) at the wrong length.
+    export PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}"
     # Enable the extension in the default databases. template1 makes it the
     # default for future databases.
     for TDE_DB in template1 "$POSTGRES_DB"; do
@@ -179,14 +183,14 @@ SQL
     # Key setup is strict: a failure fails the bootstrap loudly rather than booting
     # with no principal key, which would silently break encrypted-table creation.
     if [[ "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
-        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || { echo "pg_tde FATAL: failed to set database principal key '${TDE_KEY_NAME}'"; exit 1; }
     else
-        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
@@ -196,7 +200,7 @@ SQL
 
     # If WAL encryption is requested, create + set the server (WAL) key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
-        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create WAL server key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
@@ -204,6 +208,8 @@ SQL
             || { echo "pg_tde FATAL: failed to set WAL server key '${TDE_KEY_NAME}-wal'"; exit 1; }
     fi
 fi
+
+unset PGOPTIONS
 
 if [[ "$BOOTSTRAP" == "true" ]];then
   # initialize database

--- a/role_scripts/18/primary/start.sh
+++ b/role_scripts/18/primary/start.sh
@@ -173,9 +173,15 @@ SQL
             ;;
     esac
 
-    # Set the per-database principal key.
-    psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-        "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+    # Set the per-database principal key with the setter that matches the
+    # provider scope: file providers are database-scoped, vault/kmip are global.
+    if [[ "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+    else
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+    fi
 
     # If WAL encryption is requested, set the server key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then

--- a/role_scripts/18/primary/start.sh
+++ b/role_scripts/18/primary/start.sh
@@ -208,6 +208,22 @@ SQL
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || tde_bootstrap_fatal "failed to set global principal key '${TDE_KEY_NAME}'"
+
+        # Set a server-wide DEFAULT principal key so databases created later inherit
+        # encryption. pg_tde stores the principal key per database OID and CREATE
+        # DATABASE does NOT copy it (a key set in template1 is not carried to its
+        # clones), so without a server default the first encrypted CREATE TABLE in a
+        # newly created database fails "principal key not configured" under a
+        # cluster-wide default_table_access_method = tde_heap. The default key is a
+        # global-provider feature; the file keyring (standalone, database-scoped) has
+        # no server default, so this applies to the vault/kmip providers only. Create
+        # precedes set, and the set is strict like the principal-key set above.
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
+            || echo "pg_tde: create default key returned non-zero (may already exist), continuing to set"
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_default_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
+            || tde_bootstrap_fatal "failed to set default principal key '${TDE_KEY_NAME}-default'"
     fi
 
     # WAL encryption is global-only: the file keyring is a database-scoped

--- a/role_scripts/18/primary/start.sh
+++ b/role_scripts/18/primary/start.sh
@@ -44,7 +44,11 @@ else
     echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
 fi
 
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 
 if [[ "${SSL:-0}" == "ON" ]]; then
     echo "ssl =on" >>/tmp/postgresql.conf
@@ -140,6 +144,45 @@ echo
 
 psql+=(--username "$POSTGRES_USER" --dbname "$POSTGRES_DB")
 echo
+
+# pg_tde principal-key bootstrap. Runs once on first initialization, after the
+# database and superuser exist and before any encrypted table or the
+# default_table_access_method flip can be used. Idempotent on retries.
+if [[ "${TDE_ENABLED:-false}" == "true" && "${BOOTSTRAP}" == "true" ]]; then
+    # Enable the extension in the default databases. template1 makes it the
+    # default for future databases.
+    for TDE_DB in template1 "$POSTGRES_DB"; do
+        psql -U postgres -d "$TDE_DB" -v ON_ERROR_STOP=1 <<SQL
+CREATE EXTENSION IF NOT EXISTS ${TDE_EXTENSION:-pg_tde};
+SQL
+    done
+
+    # Register the key provider (global preferred; file is standalone only).
+    case "${TDE_PROVIDER_KIND:-}" in
+        vault)
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_add_global_key_provider_vault_v2('${TDE_PROVIDER_NAME}','${TDE_VAULT_ADDR}','${TDE_VAULT_MOUNT}','${TDE_VAULT_TOKEN_PATH}','${TDE_VAULT_CA_PATH}');" || true
+            ;;
+        kmip)
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_add_global_key_provider_kmip('${TDE_PROVIDER_NAME}','${TDE_KMIP_ADDR}',${TDE_KMIP_PORT},'${TDE_KMIP_CLIENT_CERT_PATH}','${TDE_KMIP_CLIENT_KEY_PATH}','${TDE_KMIP_CA_PATH}');" || true
+            ;;
+        file)
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_add_database_key_provider_file('${TDE_PROVIDER_NAME}','${TDE_FILE_PATH}');" || true
+            ;;
+    esac
+
+    # Set the per-database principal key.
+    psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+
+    # If WAL encryption is requested, set the server key too (global only).
+    if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_server_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" || true
+    fi
+fi
 
 if [[ "$BOOTSTRAP" == "true" ]];then
   # initialize database
@@ -268,6 +311,14 @@ fi
 mv /tmp/pg_hba.conf "$PGDATA/pg_hba.conf"
 
 touch /tmp/postgresql.conf
+# pg_tde runtime GUCs. Authored in the post-bootstrap rewrite, after the
+# extension and principal key exist, so default_table_access_method is safe.
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 if [ "$STANDBY" == "hot" ]; then
     echo "hot_standby = on" >>/tmp/postgresql.conf
 else

--- a/role_scripts/18/primary/start.sh
+++ b/role_scripts/18/primary/start.sh
@@ -179,14 +179,14 @@ SQL
     # Key setup is strict: a failure fails the bootstrap loudly rather than booting
     # with no principal key, which would silently break encrypted-table creation.
     if [[ "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || { echo "pg_tde FATAL: failed to set database principal key '${TDE_KEY_NAME}'"; exit 1; }
     else
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
@@ -196,7 +196,7 @@ SQL
 
     # If WAL encryption is requested, create + set the server (WAL) key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create WAL server key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \

--- a/role_scripts/18/primary/start.sh
+++ b/role_scripts/18/primary/start.sh
@@ -176,8 +176,18 @@ SQL
     # Register the key provider (global preferred; file is standalone only).
     case "${TDE_PROVIDER_KIND:-}" in
         vault)
-            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-                "SELECT pg_tde_add_global_key_provider_vault_v2('${TDE_PROVIDER_NAME}','${TDE_VAULT_ADDR}','${TDE_VAULT_MOUNT}','${TDE_VAULT_TOKEN_PATH}','${TDE_VAULT_CA_PATH}');" || true
+            # pg_tde_add_global_key_provider_vault_v2 has a 5-arg form and a 6-arg
+            # form that also takes a Vault Enterprise namespace. Pass the namespace
+            # (spec.tde.keyProvider.vault.namespace -> TDE_VAULT_NAMESPACE) only when
+            # it is set, so the common namespace-less case keeps the 5-arg form; the
+            # namespace was otherwise accepted in the CRD but silently dropped here.
+            if [[ -n "${TDE_VAULT_NAMESPACE:-}" ]]; then
+                psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                    "SELECT pg_tde_add_global_key_provider_vault_v2('${TDE_PROVIDER_NAME}','${TDE_VAULT_ADDR}','${TDE_VAULT_MOUNT}','${TDE_VAULT_TOKEN_PATH}','${TDE_VAULT_CA_PATH}','${TDE_VAULT_NAMESPACE}');" || true
+            else
+                psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                    "SELECT pg_tde_add_global_key_provider_vault_v2('${TDE_PROVIDER_NAME}','${TDE_VAULT_ADDR}','${TDE_VAULT_MOUNT}','${TDE_VAULT_TOKEN_PATH}','${TDE_VAULT_CA_PATH}');" || true
+            fi
             ;;
         kmip)
             psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \

--- a/role_scripts/18/standby/ha_backup_job.sh
+++ b/role_scripts/18/standby/ha_backup_job.sh
@@ -102,6 +102,7 @@ echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
     [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
     [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
     echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
 fi
 

--- a/role_scripts/18/standby/ha_backup_job.sh
+++ b/role_scripts/18/standby/ha_backup_job.sh
@@ -63,6 +63,7 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     chmod 0700 "$PGDATA"
     BASEBACKUP=pg_basebackup
     [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
+    echo "pg_tde: seeding standby with '$BASEBACKUP' (TDE_ENABLED=${TDE_ENABLED:-false})"
     if [[ "${SSL:-0}" == "ON" ]]; then
         "$BASEBACKUP" -X fetch --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
     else

--- a/role_scripts/18/standby/ha_backup_job.sh
+++ b/role_scripts/18/standby/ha_backup_job.sh
@@ -61,10 +61,12 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     mkdir -p "$PGDATA"
     rm -rf "$PGDATA"/*
     chmod 0700 "$PGDATA"
+    BASEBACKUP=pg_basebackup
+    [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
     if [[ "${SSL:-0}" == "ON" ]]; then
-        pg_basebackup -X fetch --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
+        "$BASEBACKUP" -X fetch --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
     else
-        pg_basebackup -X fetch --no-password --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST"
+        "$BASEBACKUP" -X fetch --no-password --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST"
     fi
 fi
 
@@ -91,7 +93,16 @@ echo "wal_log_hints = on" >>/tmp/postgresql.conf
 echo "archive_mode = always" >>/tmp/postgresql.conf
 echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
 
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 
 if [ "$STANDBY" == "hot" ]; then
     echo "hot_standby = on" >>/tmp/postgresql.conf

--- a/role_scripts/18/standby/remote-replica.sh
+++ b/role_scripts/18/standby/remote-replica.sh
@@ -110,6 +110,7 @@ echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
     [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
     [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
     echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
 fi
 

--- a/role_scripts/18/standby/remote-replica.sh
+++ b/role_scripts/18/standby/remote-replica.sh
@@ -69,10 +69,12 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     mkdir -p "$PGDATA"
     rm -rf "$PGDATA"/*
     chmod 0700 "$PGDATA"
+    BASEBACKUP=pg_basebackup
+    [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
     if [[ "${SOURCE_SSL:-0}" == "ON" ]]; then
-        pg_basebackup -X fetch --pgdata "$PGDATA" --username=$PRIMARY_USER_NAME --progress --host="$PRIMARY_HOST" -d "sslmode=$SOURCE_SSL_MODE sslrootcert=/tls/certs/remote/ca.crt sslcert=/tls/certs/remote/client.crt sslkey=/tls/certs/remote/client.key"
+        "$BASEBACKUP" -X fetch --pgdata "$PGDATA" --username=$PRIMARY_USER_NAME --progress --host="$PRIMARY_HOST" -d "sslmode=$SOURCE_SSL_MODE sslrootcert=/tls/certs/remote/ca.crt sslcert=/tls/certs/remote/client.crt sslkey=/tls/certs/remote/client.key"
     else
-        pg_basebackup -X fetch --no-password --pgdata "$PGDATA" --username=$PRIMARY_USER_NAME --progress --host="$PRIMARY_HOST"
+        "$BASEBACKUP" -X fetch --no-password --pgdata "$PGDATA" --username=$PRIMARY_USER_NAME --progress --host="$PRIMARY_HOST"
     fi
 fi
 
@@ -99,7 +101,16 @@ echo "wal_log_hints = on" >>/tmp/postgresql.conf
 echo "archive_mode = always" >>/tmp/postgresql.conf
 echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
 
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 
 if [ "$STANDBY" == "hot" ]; then
     echo "hot_standby = on" >>/tmp/postgresql.conf

--- a/role_scripts/18/standby/remote-replica.sh
+++ b/role_scripts/18/standby/remote-replica.sh
@@ -71,6 +71,7 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     chmod 0700 "$PGDATA"
     BASEBACKUP=pg_basebackup
     [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
+    echo "pg_tde: seeding standby with '$BASEBACKUP' (TDE_ENABLED=${TDE_ENABLED:-false})"
     if [[ "${SOURCE_SSL:-0}" == "ON" ]]; then
         "$BASEBACKUP" -X fetch --pgdata "$PGDATA" --username=$PRIMARY_USER_NAME --progress --host="$PRIMARY_HOST" -d "sslmode=$SOURCE_SSL_MODE sslrootcert=/tls/certs/remote/ca.crt sslcert=/tls/certs/remote/client.crt sslkey=/tls/certs/remote/client.key"
     else

--- a/role_scripts/18/standby/run.sh
+++ b/role_scripts/18/standby/run.sh
@@ -169,6 +169,7 @@ echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
     [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
     [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
     echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
 fi
 

--- a/role_scripts/18/standby/run.sh
+++ b/role_scripts/18/standby/run.sh
@@ -118,6 +118,7 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     chmod 0700 "$PGDATA"
     BASEBACKUP=pg_basebackup
     [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
+    echo "pg_tde: seeding standby with '$BASEBACKUP' (TDE_ENABLED=${TDE_ENABLED:-false})"
     if [[ "${SSL:-0}" == "ON" ]]; then
         "$BASEBACKUP" -Xs -c fast --pgdata "$PGDATA" --max-rate=1024M --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
     else

--- a/role_scripts/18/standby/run.sh
+++ b/role_scripts/18/standby/run.sh
@@ -89,7 +89,6 @@ if [[ "$WAL_LIMIT_POLICY" == "ReplicationSlot" ]]; then
   done
 fi
 
-
 if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     if [[ ! -e "/var/pv/IGNORE_FILESYSTEM_MOUNT_CHECK" ]]; then
       # Robust /var/pv mount availability check before any destructive operation or basebackup
@@ -117,17 +116,17 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     mkdir -p "$PGDATA"
     rm -rf "$PGDATA"/*
     chmod 0700 "$PGDATA"
+    BASEBACKUP=pg_basebackup
+    [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
     if [[ "${SSL:-0}" == "ON" ]]; then
-        pg_basebackup -Xs -c fast --pgdata "$PGDATA" --max-rate=1024M --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
+        "$BASEBACKUP" -Xs -c fast --pgdata "$PGDATA" --max-rate=1024M --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
     else
-        pg_basebackup -Xs -c fast --no-password --max-rate=1024M --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST"
+        "$BASEBACKUP" -Xs -c fast --no-password --max-rate=1024M --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST"
     fi
     touch /var/pv/data/standby.signal
 else
     /run_scripts/role/warm_stanby.sh
 fi
-
-
 
 # setup postgresql.conf
 touch /tmp/postgresql.conf
@@ -161,7 +160,16 @@ else
     echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
 fi
 
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 
 if [ "$STANDBY" == "hot" ]; then
     echo "hot_standby = on" >>/tmp/postgresql.conf

--- a/role_scripts/18/standby/warm_stanby.sh
+++ b/role_scripts/18/standby/warm_stanby.sh
@@ -47,6 +47,7 @@ echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
     [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
     [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
     echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
 fi
 

--- a/role_scripts/18/standby/warm_stanby.sh
+++ b/role_scripts/18/standby/warm_stanby.sh
@@ -39,7 +39,16 @@ echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
 
 echo "hot_standby = off" >>/tmp/postgresql.conf
 
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 
 if [[ "$STREAMING" == "synchronous" ]]; then
     # setup synchronous streaming replication

--- a/role_scripts/9/primary/start.sh
+++ b/role_scripts/9/primary/start.sh
@@ -115,20 +115,35 @@ SQL
             ;;
     esac
 
-    # Set the per-database principal key with the setter that matches the
-    # provider scope: file providers are database-scoped, vault/kmip are global.
+    # Create then set the per-database principal key. pg_tde requires the key to
+    # exist before it can be set as principal, so create precedes set. The setter
+    # matches the provider scope (file is database-scoped, vault/kmip are global).
+    # Key setup is strict: a failure fails the bootstrap loudly rather than booting
+    # with no principal key, which would silently break encrypted-table creation.
     if [[ "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+            "SELECT pg_tde_create_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
+            || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
+            || { echo "pg_tde FATAL: failed to set database principal key '${TDE_KEY_NAME}'"; exit 1; }
     else
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+            "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
+            || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
+            || { echo "pg_tde FATAL: failed to set global principal key '${TDE_KEY_NAME}'"; exit 1; }
     fi
 
-    # If WAL encryption is requested, set the server key too (global only).
+    # If WAL encryption is requested, create + set the server (WAL) key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_set_server_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" || true
+            "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
+            || echo "pg_tde: create WAL server key returned non-zero (may already exist), continuing to set"
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_server_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
+            || { echo "pg_tde FATAL: failed to set WAL server key '${TDE_KEY_NAME}-wal'"; exit 1; }
     fi
 fi
 

--- a/role_scripts/9/primary/start.sh
+++ b/role_scripts/9/primary/start.sh
@@ -121,14 +121,14 @@ SQL
     # Key setup is strict: a failure fails the bootstrap loudly rather than booting
     # with no principal key, which would silently break encrypted-table creation.
     if [[ "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || { echo "pg_tde FATAL: failed to set database principal key '${TDE_KEY_NAME}'"; exit 1; }
     else
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
@@ -138,7 +138,7 @@ SQL
 
     # If WAL encryption is requested, create + set the server (WAL) key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create WAL server key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \

--- a/role_scripts/9/primary/start.sh
+++ b/role_scripts/9/primary/start.sh
@@ -115,9 +115,15 @@ SQL
             ;;
     esac
 
-    # Set the per-database principal key.
-    psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-        "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+    # Set the per-database principal key with the setter that matches the
+    # provider scope: file providers are database-scoped, vault/kmip are global.
+    if [[ "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+    else
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+    fi
 
     # If WAL encryption is requested, set the server key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then

--- a/role_scripts/9/primary/start.sh
+++ b/role_scripts/9/primary/start.sh
@@ -118,8 +118,18 @@ SQL
     # Register the key provider (global preferred; file is standalone only).
     case "${TDE_PROVIDER_KIND:-}" in
         vault)
-            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-                "SELECT pg_tde_add_global_key_provider_vault_v2('${TDE_PROVIDER_NAME}','${TDE_VAULT_ADDR}','${TDE_VAULT_MOUNT}','${TDE_VAULT_TOKEN_PATH}','${TDE_VAULT_CA_PATH}');" || true
+            # pg_tde_add_global_key_provider_vault_v2 has a 5-arg form and a 6-arg
+            # form that also takes a Vault Enterprise namespace. Pass the namespace
+            # (spec.tde.keyProvider.vault.namespace -> TDE_VAULT_NAMESPACE) only when
+            # it is set, so the common namespace-less case keeps the 5-arg form; the
+            # namespace was otherwise accepted in the CRD but silently dropped here.
+            if [[ -n "${TDE_VAULT_NAMESPACE:-}" ]]; then
+                psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                    "SELECT pg_tde_add_global_key_provider_vault_v2('${TDE_PROVIDER_NAME}','${TDE_VAULT_ADDR}','${TDE_VAULT_MOUNT}','${TDE_VAULT_TOKEN_PATH}','${TDE_VAULT_CA_PATH}','${TDE_VAULT_NAMESPACE}');" || true
+            else
+                psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                    "SELECT pg_tde_add_global_key_provider_vault_v2('${TDE_PROVIDER_NAME}','${TDE_VAULT_ADDR}','${TDE_VAULT_MOUNT}','${TDE_VAULT_TOKEN_PATH}','${TDE_VAULT_CA_PATH}');" || true
+            fi
             ;;
         kmip)
             psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \

--- a/role_scripts/9/primary/start.sh
+++ b/role_scripts/9/primary/start.sh
@@ -152,6 +152,13 @@ SQL
             || tde_bootstrap_fatal "failed to set global principal key '${TDE_KEY_NAME}'"
     fi
 
+    # WAL encryption is global-only: the file keyring is a database-scoped
+    # provider and cannot back a server key. The operator webhook already rejects
+    # this combination, so this is a fail-closed backstop with a clear message
+    # (instead of a swallowed error that crash-loops on the misleading set-key fatal).
+    if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" && "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
+        tde_bootstrap_fatal "WAL encryption requires a global (vault or kmip) key provider; the file keyring cannot back WAL encryption"
+    fi
     # If WAL encryption is requested, create + set the server (WAL) key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \

--- a/role_scripts/9/primary/start.sh
+++ b/role_scripts/9/primary/start.sh
@@ -91,6 +91,10 @@ echo
 # database and superuser exist and before any encrypted table or the
 # default_table_access_method flip can be used. Idempotent on retries.
 if [[ "${TDE_ENABLED:-false}" == "true" && "${BOOTSTRAP}" == "true" ]]; then
+    # Run every pg_tde key operation in this block at the configured cipher. The
+    # post-bootstrap config that carries pg_tde.cipher is not loaded yet, so without
+    # this the principal key would be created (and validated) at the wrong length.
+    export PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}"
     # Enable the extension in the default databases. template1 makes it the
     # default for future databases.
     for TDE_DB in template1 "$POSTGRES_DB"; do
@@ -121,14 +125,14 @@ SQL
     # Key setup is strict: a failure fails the bootstrap loudly rather than booting
     # with no principal key, which would silently break encrypted-table creation.
     if [[ "${TDE_PROVIDER_KIND:-}" == "file" ]]; then
-        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || { echo "pg_tde FATAL: failed to set database principal key '${TDE_KEY_NAME}'"; exit 1; }
     else
-        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
@@ -138,7 +142,7 @@ SQL
 
     # If WAL encryption is requested, create + set the server (WAL) key too (global only).
     if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
-        PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}" psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create WAL server key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
@@ -146,6 +150,8 @@ SQL
             || { echo "pg_tde FATAL: failed to set WAL server key '${TDE_KEY_NAME}-wal'"; exit 1; }
     fi
 fi
+
+unset PGOPTIONS
 
 if [[ "$BOOTSTRAP" == "true" ]];then
   # initialize database

--- a/role_scripts/9/primary/start.sh
+++ b/role_scripts/9/primary/start.sh
@@ -29,7 +29,11 @@ fi
 echo "wal_log_hints = on" >>/tmp/postgresql.conf
 echo "archive_mode = always" >>/tmp/postgresql.conf
 echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 echo "max_replication_slots = 90" >>/tmp/postgresql.conf
 
 if [[ "${SSL:-0}" == "ON" ]]; then
@@ -82,6 +86,45 @@ echo
 
 psql+=(--username "$POSTGRES_USER" --dbname "$POSTGRES_DB")
 echo
+
+# pg_tde principal-key bootstrap. Runs once on first initialization, after the
+# database and superuser exist and before any encrypted table or the
+# default_table_access_method flip can be used. Idempotent on retries.
+if [[ "${TDE_ENABLED:-false}" == "true" && "${BOOTSTRAP}" == "true" ]]; then
+    # Enable the extension in the default databases. template1 makes it the
+    # default for future databases.
+    for TDE_DB in template1 "$POSTGRES_DB"; do
+        psql -U postgres -d "$TDE_DB" -v ON_ERROR_STOP=1 <<SQL
+CREATE EXTENSION IF NOT EXISTS ${TDE_EXTENSION:-pg_tde};
+SQL
+    done
+
+    # Register the key provider (global preferred; file is standalone only).
+    case "${TDE_PROVIDER_KIND:-}" in
+        vault)
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_add_global_key_provider_vault_v2('${TDE_PROVIDER_NAME}','${TDE_VAULT_ADDR}','${TDE_VAULT_MOUNT}','${TDE_VAULT_TOKEN_PATH}','${TDE_VAULT_CA_PATH}');" || true
+            ;;
+        kmip)
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_add_global_key_provider_kmip('${TDE_PROVIDER_NAME}','${TDE_KMIP_ADDR}',${TDE_KMIP_PORT},'${TDE_KMIP_CLIENT_CERT_PATH}','${TDE_KMIP_CLIENT_KEY_PATH}','${TDE_KMIP_CA_PATH}');" || true
+            ;;
+        file)
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_add_database_key_provider_file('${TDE_PROVIDER_NAME}','${TDE_FILE_PATH}');" || true
+            ;;
+    esac
+
+    # Set the per-database principal key.
+    psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+        "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" || true
+
+    # If WAL encryption is requested, set the server key too (global only).
+    if [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]]; then
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_server_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" || true
+    fi
+fi
 
 if [[ "$BOOTSTRAP" == "true" ]];then
   # initialize database
@@ -167,6 +210,14 @@ fi
 mv /tmp/pg_hba.conf "$PGDATA/pg_hba.conf"
 
 touch /tmp/postgresql.conf
+# pg_tde runtime GUCs. Authored in the post-bootstrap rewrite, after the
+# extension and principal key exist, so default_table_access_method is safe.
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 if [ "$STANDBY" == "hot" ]; then
     echo "hot_standby = on" >>/tmp/postgresql.conf
 else
@@ -208,4 +259,3 @@ fi
 
 # ref: https://superuser.com/a/246841/985093
 cat /tmp/postgresql.conf $PGDATA/postgresql.conf >"/tmp/postgresql.conf.tmp" && mv "/tmp/postgresql.conf.tmp" "$PGDATA/postgresql.conf"
-

--- a/role_scripts/9/primary/start.sh
+++ b/role_scripts/9/primary/start.sh
@@ -150,6 +150,22 @@ SQL
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || tde_bootstrap_fatal "failed to set global principal key '${TDE_KEY_NAME}'"
+
+        # Set a server-wide DEFAULT principal key so databases created later inherit
+        # encryption. pg_tde stores the principal key per database OID and CREATE
+        # DATABASE does NOT copy it (a key set in template1 is not carried to its
+        # clones), so without a server default the first encrypted CREATE TABLE in a
+        # newly created database fails "principal key not configured" under a
+        # cluster-wide default_table_access_method = tde_heap. The default key is a
+        # global-provider feature; the file keyring (standalone, database-scoped) has
+        # no server default, so this applies to the vault/kmip providers only. Create
+        # precedes set, and the set is strict like the principal-key set above.
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
+            || echo "pg_tde: create default key returned non-zero (may already exist), continuing to set"
+        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_tde_set_default_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
+            || tde_bootstrap_fatal "failed to set default principal key '${TDE_KEY_NAME}-default'"
     fi
 
     # WAL encryption is global-only: the file keyring is a database-scoped

--- a/role_scripts/9/primary/start.sh
+++ b/role_scripts/9/primary/start.sh
@@ -155,17 +155,22 @@ SQL
         # encryption. pg_tde stores the principal key per database OID and CREATE
         # DATABASE does NOT copy it (a key set in template1 is not carried to its
         # clones), so without a server default the first encrypted CREATE TABLE in a
-        # newly created database fails "principal key not configured" under a
-        # cluster-wide default_table_access_method = tde_heap. The default key is a
-        # global-provider feature; the file keyring (standalone, database-scoped) has
-        # no server default, so this applies to the vault/kmip providers only. Create
-        # precedes set, and the set is strict like the principal-key set above.
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
-            || echo "pg_tde: create default key returned non-zero (may already exist), continuing to set"
-        psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-            "SELECT pg_tde_set_default_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
-            || tde_bootstrap_fatal "failed to set default principal key '${TDE_KEY_NAME}-default'"
+        # newly created database fails "principal key not configured". This only
+        # matters when new tables are encrypted by default or enforced cluster-wide,
+        # so gate it on TDE_DEFAULT_AM/TDE_ENFORCE (mirroring how the WAL block below
+        # gates on TDE_ENCRYPT_WAL): a plain opt-in-per-table cluster does not need a
+        # server default and should not take the strict-set crash-loop risk for it.
+        # The default key is a global-provider feature; the file keyring (standalone,
+        # database-scoped) has no server default, so this applies to vault/kmip only.
+        # Create precedes set, and the set is strict like the principal-key set above.
+        if [[ "${TDE_DEFAULT_AM:-false}" == "true" || "${TDE_ENFORCE:-false}" == "true" ]]; then
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
+                || echo "pg_tde: create default key returned non-zero (may already exist), continuing to set"
+            psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
+                "SELECT pg_tde_set_default_key_using_global_key_provider('${TDE_KEY_NAME}-default','${TDE_PROVIDER_NAME}');" \
+                || tde_bootstrap_fatal "failed to set default principal key '${TDE_KEY_NAME}-default'"
+        fi
     fi
 
     # WAL encryption is global-only: the file keyring is a database-scoped

--- a/role_scripts/9/primary/start.sh
+++ b/role_scripts/9/primary/start.sh
@@ -95,6 +95,18 @@ if [[ "${TDE_ENABLED:-false}" == "true" && "${BOOTSTRAP}" == "true" ]]; then
     # post-bootstrap config that carries pg_tde.cipher is not loaded yet, so without
     # this the principal key would be created (and validated) at the wrong length.
     export PGOPTIONS="-c pg_tde.cipher=${TDE_CIPHER:-aes_128}"
+    # tde_bootstrap_fatal aborts a failed first-time TDE bootstrap loudly. This runs
+    # only during initial initialization (BOOTSTRAP=true), so there is no user data
+    # yet; wipe the half-initialized data dir and exit non-zero. That forces a full
+    # re-bootstrap on the next start instead of falling through to a keyless boot
+    # (which would silently disable encryption). The pod crash-loops visibly until
+    # the key provider is reachable.
+    tde_bootstrap_fatal() {
+        echo "pg_tde FATAL: $1"
+        pg_ctl -D "$PGDATA" -m immediate -w stop || true
+        rm -rf "${PGDATA:?}"/* || true
+        exit 1
+    }
     # Enable the extension in the default databases. template1 makes it the
     # default for future databases.
     for TDE_DB in template1 "$POSTGRES_DB"; do
@@ -130,14 +142,14 @@ SQL
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_database_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
-            || { echo "pg_tde FATAL: failed to set database principal key '${TDE_KEY_NAME}'"; exit 1; }
+            || tde_bootstrap_fatal "failed to set database principal key '${TDE_KEY_NAME}'"
     else
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_create_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
             || echo "pg_tde: create principal key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_key_using_global_key_provider('${TDE_KEY_NAME}','${TDE_PROVIDER_NAME}');" \
-            || { echo "pg_tde FATAL: failed to set global principal key '${TDE_KEY_NAME}'"; exit 1; }
+            || tde_bootstrap_fatal "failed to set global principal key '${TDE_KEY_NAME}'"
     fi
 
     # If WAL encryption is requested, create + set the server (WAL) key too (global only).
@@ -147,7 +159,7 @@ SQL
             || echo "pg_tde: create WAL server key returned non-zero (may already exist), continuing to set"
         psql -U postgres -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
             "SELECT pg_tde_set_server_key_using_global_key_provider('${TDE_KEY_NAME}-wal','${TDE_PROVIDER_NAME}');" \
-            || { echo "pg_tde FATAL: failed to set WAL server key '${TDE_KEY_NAME}-wal'"; exit 1; }
+            || tde_bootstrap_fatal "failed to set WAL server key '${TDE_KEY_NAME}-wal'"
     fi
 fi
 

--- a/role_scripts/9/standby/ha_backup_job.sh
+++ b/role_scripts/9/standby/ha_backup_job.sh
@@ -60,10 +60,12 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     mkdir -p "$PGDATA"
     rm -rf "$PGDATA"/*
     chmod 0700 "$PGDATA"
+    BASEBACKUP=pg_basebackup
+    [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
     if [[ "${SSL:-0}" == "ON" ]]; then
-        pg_basebackup -X fetch --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
+        "$BASEBACKUP" -X fetch --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
     else
-        pg_basebackup -X fetch --no-password --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST"
+        "$BASEBACKUP" -X fetch --no-password --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST"
     fi
 fi
 
@@ -84,9 +86,17 @@ else
   echo "wal_keep_segments = 160" >>/tmp/postgresql.conf
 fi
 
-
 echo "wal_log_hints = on" >>/tmp/postgresql.conf
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 echo "max_replication_slots = 90" >>/tmp/postgresql.conf
 
 echo "archive_mode = always" >>/tmp/postgresql.conf

--- a/role_scripts/9/standby/ha_backup_job.sh
+++ b/role_scripts/9/standby/ha_backup_job.sh
@@ -62,6 +62,7 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     chmod 0700 "$PGDATA"
     BASEBACKUP=pg_basebackup
     [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
+    echo "pg_tde: seeding standby with '$BASEBACKUP' (TDE_ENABLED=${TDE_ENABLED:-false})"
     if [[ "${SSL:-0}" == "ON" ]]; then
         "$BASEBACKUP" -X fetch --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
     else

--- a/role_scripts/9/standby/ha_backup_job.sh
+++ b/role_scripts/9/standby/ha_backup_job.sh
@@ -96,6 +96,7 @@ echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
     [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
     [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
     echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
 fi
 echo "max_replication_slots = 90" >>/tmp/postgresql.conf

--- a/role_scripts/9/standby/run.sh
+++ b/role_scripts/9/standby/run.sh
@@ -119,10 +119,12 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     mkdir -p "$PGDATA"
     rm -rf "$PGDATA"/*
     chmod 0700 "$PGDATA"
+    BASEBACKUP=pg_basebackup
+    [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
     if [[ "${SSL:-0}" == "ON" ]]; then
-        pg_basebackup -X fetch --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
+        "$BASEBACKUP" -X fetch --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
     else
-        pg_basebackup -X fetch --no-password --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST"
+        "$BASEBACKUP" -X fetch --no-password --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST"
     fi
 else
     /run_scripts/role/warm_stanby.sh
@@ -149,7 +151,16 @@ echo "wal_log_hints = on" >>/tmp/postgresql.conf
 
 echo "archive_mode = always" >>/tmp/postgresql.conf
 echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 
 if [ "$STANDBY" == "hot" ]; then
     echo "hot_standby = on" >>/tmp/postgresql.conf

--- a/role_scripts/9/standby/run.sh
+++ b/role_scripts/9/standby/run.sh
@@ -121,6 +121,7 @@ if [[ ! -e "$PGDATA/PG_VERSION" ]]; then
     chmod 0700 "$PGDATA"
     BASEBACKUP=pg_basebackup
     [[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
+    echo "pg_tde: seeding standby with '$BASEBACKUP' (TDE_ENABLED=${TDE_ENABLED:-false})"
     if [[ "${SSL:-0}" == "ON" ]]; then
         "$BASEBACKUP" -X fetch --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST" -d "sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key"
     else

--- a/role_scripts/9/standby/run.sh
+++ b/role_scripts/9/standby/run.sh
@@ -160,6 +160,7 @@ echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
     [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
     [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
     echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
 fi
 

--- a/role_scripts/9/standby/warm_stanby.sh
+++ b/role_scripts/9/standby/warm_stanby.sh
@@ -39,6 +39,7 @@ echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
 if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
     [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
     [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    [[ "${TDE_DEFAULT_AM:-false}" == "true" ]] && echo "default_table_access_method = tde_heap" >>/tmp/postgresql.conf
     echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
 fi
 

--- a/role_scripts/9/standby/warm_stanby.sh
+++ b/role_scripts/9/standby/warm_stanby.sh
@@ -31,7 +31,16 @@ fi
 echo "max_replication_slots = 90" >>/tmp/postgresql.conf
 
 echo "wal_log_hints = on" >>/tmp/postgresql.conf
-echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 
 echo "archive_mode = always" >>/tmp/postgresql.conf
 echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf

--- a/scripts/do_pg_basebackup.sh
+++ b/scripts/do_pg_basebackup.sh
@@ -8,8 +8,10 @@ rm -rf "$PGDATA"/*
 chmod 0700 "$PGDATA"
 echo "attempting pg_basebackup..."
 
+BASEBACKUP=pg_basebackup
+[[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
 if [[ "${SSL:-0}" == "ON" ]]; then
-    pg_basebackup -Xs -c fast --pgdata "$PGDATA" --max-rate=1024M --username=postgres --progress --host="$PRIMARY_HOST" -d "password=$POSTGRES_PASSWORD sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key" &>/dev/null
+    "$BASEBACKUP" -Xs -c fast --pgdata "$PGDATA" --max-rate=1024M --username=postgres --progress --host="$PRIMARY_HOST" -d "password=$POSTGRES_PASSWORD sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key" &>/dev/null
 else
-    pg_basebackup -Xs -c fast --no-password --max-rate=1024M --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST" -d "password=$POSTGRES_PASSWORD" &>/dev/null
+    "$BASEBACKUP" -Xs -c fast --no-password --max-rate=1024M --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST" -d "password=$POSTGRES_PASSWORD" &>/dev/null
 fi

--- a/scripts/recover_replica.sh
+++ b/scripts/recover_replica.sh
@@ -8,10 +8,12 @@ mv /run_scripts/role/run.sh /run_scripts/role/run.sh.bc
 pg_ctl stop -D $PGDATA
 rm -rf /var/pv/data
 
+BASEBACKUP=pg_basebackup
+[[ "${TDE_ENABLED:-false}" == "true" ]] && BASEBACKUP=pg_tde_basebackup
 if [[ "${SSL:-0}" == "ON" ]]; then
-    pg_basebackup -Xs -c fast --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST" -d "password=$POSTGRES_PASSWORD sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key" &>/dev/null
+    "$BASEBACKUP" -Xs -c fast --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST" -d "password=$POSTGRES_PASSWORD sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key" &>/dev/null
 else
-    pg_basebackup -Xs -c fast --no-password --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST" -d "password=$POSTGRES_PASSWORD" &>/dev/null
+    "$BASEBACKUP" -Xs -c fast --no-password --pgdata "$PGDATA" --username=postgres --progress --host="$PRIMARY_HOST" -d "password=$POSTGRES_PASSWORD" &>/dev/null
 fi
 
 touch /var/pv/data/standby.signal

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -84,6 +84,18 @@ fi
 echo "archive_mode = always" >>/tmp/postgresql.conf
 echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
 echo "logging_collector = on" >>/tmp/postgresql.conf
+# pg_tde must be preloaded during recovery/restore or an encrypted
+# cluster corrupts. Compose the list with pg_tde first when enabled.
+PRELOAD="pg_stat_statements"
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    PRELOAD="${TDE_EXTENSION:-pg_tde},${PRELOAD}"
+fi
+echo "shared_preload_libraries = '${PRELOAD}'" >>/tmp/postgresql.conf
+if [[ "${TDE_ENABLED:-false}" == "true" ]]; then
+    [[ "${TDE_ENCRYPT_WAL:-false}" == "true" ]] && echo "pg_tde.wal_encrypt = on" >>/tmp/postgresql.conf
+    [[ "${TDE_ENFORCE:-false}" == "true" ]] && echo "pg_tde.enforce_encryption = on" >>/tmp/postgresql.conf
+    echo "pg_tde.cipher = '${TDE_CIPHER:-aes_128}'" >>/tmp/postgresql.conf
+fi
 cat /run_scripts/role/postgresql.conf >>/tmp/postgresql.conf
 mv /tmp/postgresql.conf "$PGDATA/postgresql.conf"
 echo "max_replication_slots = 90" >>/tmp/postgresql.conf
@@ -111,7 +123,6 @@ until pg_isready -U postgres; do
     done
   fi
 done
-
 
 if [[ "$HOST" =~ -0$ ]]; then
   echo "Primary restore mode"


### PR DESCRIPTION
Adds pg_tde (Percona Transparent Data Encryption) support to the Postgres init container scripts. Gated entirely on `TDE_ENABLED`, so non-TDE clusters are unaffected.

## What this does
- Composes `pg_tde` into `shared_preload_libraries` in every config-authoring path, including the PITR restore path (an encrypted cluster must preload pg_tde during recovery or it corrupts).
- Adds the pg_tde GUCs (`pg_tde.wal_encrypt`, `pg_tde.enforce_encryption`, `pg_tde.cipher`) and the `default_table_access_method=tde_heap` flip in the post-bootstrap config rewrite.
- Adds the principal-key bootstrap block in every version's `primary/start.sh` (CREATE EXTENSION on template1 + the app db, register the key provider, set the principal and server keys) on first initialization only.
- Seeds replicas with `pg_tde_basebackup` instead of `pg_basebackup` when TDE is enabled.

Applied identically across PostgreSQL 9-18. The operator sets the `TDE_*` env contract. Requires a Percona Server for PostgreSQL 17.x image that bundles pg_tde and the CLI tools. Part of the pg_tde effort tracked in kubedb/apimachinery#1831.