### PR TITLE
Add dbname=postgres to primary_conninfo for replication slot

### DIFF
--- a/role_scripts/17/primary/start.sh
+++ b/role_scripts/17/primary/start.sh
@@ -64,14 +64,19 @@ fi
 # ****************** Recovery config **************************
 echo "recovery_target_timeline = 'latest'" >>/tmp/postgresql.conf
 # primary_conninfo is used for streaming replication
+CONNINFO_DBNAME=""
+if [[ "$WAL_LIMIT_POLICY" == "ReplicationSlot" ]]; then
+    CONNINFO_DBNAME=" dbname=postgres"
+fi
+
 if [[ "${SSL:-0}" == "ON" ]]; then
     if [[ "$CLIENT_AUTH_MODE" == "cert" ]]; then
-        echo "primary_conninfo = 'application_name=$HOSTNAME host=$PRIMARY_HOST user=$POSTGRES_USER password=$POSTGRES_PASSWORD sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key'" >>/tmp/postgresql.conf
+        echo "primary_conninfo = 'application_name=$HOSTNAME host=$PRIMARY_HOST user=$POSTGRES_USER password=$POSTGRES_PASSWORD sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key$CONNINFO_DBNAME'" >>/tmp/postgresql.conf
     else
-        echo "primary_conninfo = 'application_name=$HOSTNAME host=$PRIMARY_HOST user=$POSTGRES_USER password=$POSTGRES_PASSWORD sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt'" >>/tmp/postgresql.conf
+        echo "primary_conninfo = 'application_name=$HOSTNAME host=$PRIMARY_HOST user=$POSTGRES_USER password=$POSTGRES_PASSWORD sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt$CONNINFO_DBNAME'" >>/tmp/postgresql.conf
     fi
 else
-    echo "primary_conninfo = 'application_name=$HOSTNAME host=$PRIMARY_HOST user=$POSTGRES_USER password=$POSTGRES_PASSWORD'" >>/tmp/postgresql.conf
+    echo "primary_conninfo = 'application_name=$HOSTNAME host=$PRIMARY_HOST user=$POSTGRES_USER password=$POSTGRES_PASSWORD$CONNINFO_DBNAME'" >>/tmp/postgresql.conf
 fi
 
 cat /run_scripts/role/postgresql.conf >>/tmp/postgresql.conf

--- a/role_scripts/17/standby/remote-replica.sh
+++ b/role_scripts/17/standby/remote-replica.sh
@@ -128,10 +128,15 @@ fi
 # ****************** Recovery config **************************
 echo "recovery_target_timeline = 'latest'" >>/tmp/postgresql.conf
 # primary_conninfo is used for streaming replication
+CONNINFO_DBNAME=""
+if [[ "$WAL_LIMIT_POLICY" == "ReplicationSlot" ]]; then
+    CONNINFO_DBNAME=" dbname=postgres"
+fi
+
 if [[ "${SOURCE_SSL:-0}" == "ON" ]]; then
-    echo "primary_conninfo = 'application_name=$HOSTNAME host=$PRIMARY_HOST user=$PRIMARY_USER_NAME password=$PRIMARY_PASSWORD sslmode=$SOURCE_SSL_MODE sslrootcert=/tls/certs/remote/ca.crt sslcert=/tls/certs/remote/client.crt sslkey=/tls/certs/remote/client.key'" >>/tmp/postgresql.conf
+    echo "primary_conninfo = 'application_name=$HOSTNAME host=$PRIMARY_HOST user=$PRIMARY_USER_NAME password=$PRIMARY_PASSWORD sslmode=$SOURCE_SSL_MODE sslrootcert=/tls/certs/remote/ca.crt sslcert=/tls/certs/remote/client.crt sslkey=/tls/certs/remote/client.key$CONNINFO_DBNAME'" >>/tmp/postgresql.conf
 else
-    echo "primary_conninfo = 'application_name=$HOSTNAME host=$PRIMARY_HOST user=$PRIMARY_USER_NAME password=$PRIMARY_PASSWORD'" >>/tmp/postgresql.conf
+    echo "primary_conninfo = 'application_name=$HOSTNAME host=$PRIMARY_HOST user=$PRIMARY_USER_NAME password=$PRIMARY_PASSWORD$CONNINFO_DBNAME'" >>/tmp/postgresql.conf
 fi
 
 cat /run_scripts/role/postgresql.conf >>/tmp/postgresql.conf

--- a/role_scripts/17/standby/run.sh
+++ b/role_scripts/17/standby/run.sh
@@ -217,14 +217,19 @@ fi
 # ****************** Recovery config **************************
 echo "recovery_target_timeline = 'latest'" >>/tmp/postgresql.conf
 # primary_conninfo is used for streaming replication
+CONNINFO_DBNAME=""
+if [[ "$WAL_LIMIT_POLICY" == "ReplicationSlot" ]]; then
+    CONNINFO_DBNAME=" dbname=postgres"
+fi
+
 if [[ "${SSL:-0}" == "ON" ]]; then
     if [[ "$CLIENT_AUTH_MODE" == "cert" ]]; then
-        echo "primary_conninfo = 'application_name=$HOSTNAME host=$PRIMARY_HOST user=$POSTGRES_USER password=$POSTGRES_PASSWORD sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key'" >>/tmp/postgresql.conf
+        echo "primary_conninfo = 'application_name=$HOSTNAME host=$PRIMARY_HOST user=$POSTGRES_USER password=$POSTGRES_PASSWORD sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key$CONNINFO_DBNAME'" >>/tmp/postgresql.conf
     else
-        echo "primary_conninfo = 'application_name=$HOSTNAME host=$PRIMARY_HOST user=$POSTGRES_USER password=$POSTGRES_PASSWORD sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt'" >>/tmp/postgresql.conf
+        echo "primary_conninfo = 'application_name=$HOSTNAME host=$PRIMARY_HOST user=$POSTGRES_USER password=$POSTGRES_PASSWORD sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt$CONNINFO_DBNAME'" >>/tmp/postgresql.conf
     fi
 else
-    echo "primary_conninfo = 'application_name=$HOSTNAME host=$PRIMARY_HOST user=$POSTGRES_USER password=$POSTGRES_PASSWORD'" >>/tmp/postgresql.conf
+    echo "primary_conninfo = 'application_name=$HOSTNAME host=$PRIMARY_HOST user=$POSTGRES_USER password=$POSTGRES_PASSWORD$CONNINFO_DBNAME'" >>/tmp/postgresql.conf
 fi
 
 cat /run_scripts/role/postgresql.conf >>/tmp/postgresql.conf

--- a/role_scripts/18/primary/start.sh
+++ b/role_scripts/18/primary/start.sh
@@ -64,14 +64,19 @@ fi
 # ****************** Recovery config **************************
 echo "recovery_target_timeline = 'latest'" >>/tmp/postgresql.conf
 # primary_conninfo is used for streaming replication
+CONNINFO_DBNAME=""
+if [[ "$WAL_LIMIT_POLICY" == "ReplicationSlot" ]]; then
+    CONNINFO_DBNAME=" dbname=postgres"
+fi
+
 if [[ "${SSL:-0}" == "ON" ]]; then
     if [[ "$CLIENT_AUTH_MODE" == "cert" ]]; then
-        echo "primary_conninfo = 'application_name=$HOSTNAME host=$PRIMARY_HOST user=$POSTGRES_USER password=$POSTGRES_PASSWORD sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key'" >>/tmp/postgresql.conf
+        echo "primary_conninfo = 'application_name=$HOSTNAME host=$PRIMARY_HOST user=$POSTGRES_USER password=$POSTGRES_PASSWORD sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key$CONNINFO_DBNAME'" >>/tmp/postgresql.conf
     else
-        echo "primary_conninfo = 'application_name=$HOSTNAME host=$PRIMARY_HOST user=$POSTGRES_USER password=$POSTGRES_PASSWORD sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt'" >>/tmp/postgresql.conf
+        echo "primary_conninfo = 'application_name=$HOSTNAME host=$PRIMARY_HOST user=$POSTGRES_USER password=$POSTGRES_PASSWORD sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt$CONNINFO_DBNAME'" >>/tmp/postgresql.conf
     fi
 else
-    echo "primary_conninfo = 'application_name=$HOSTNAME host=$PRIMARY_HOST user=$POSTGRES_USER password=$POSTGRES_PASSWORD'" >>/tmp/postgresql.conf
+    echo "primary_conninfo = 'application_name=$HOSTNAME host=$PRIMARY_HOST user=$POSTGRES_USER password=$POSTGRES_PASSWORD$CONNINFO_DBNAME'" >>/tmp/postgresql.conf
 fi
 
 cat /run_scripts/role/postgresql.conf >>/tmp/postgresql.conf

--- a/role_scripts/18/standby/remote-replica.sh
+++ b/role_scripts/18/standby/remote-replica.sh
@@ -128,10 +128,15 @@ fi
 # ****************** Recovery config **************************
 echo "recovery_target_timeline = 'latest'" >>/tmp/postgresql.conf
 # primary_conninfo is used for streaming replication
+CONNINFO_DBNAME=""
+if [[ "$WAL_LIMIT_POLICY" == "ReplicationSlot" ]]; then
+    CONNINFO_DBNAME=" dbname=postgres"
+fi
+
 if [[ "${SOURCE_SSL:-0}" == "ON" ]]; then
-    echo "primary_conninfo = 'application_name=$HOSTNAME host=$PRIMARY_HOST user=$PRIMARY_USER_NAME password=$PRIMARY_PASSWORD sslmode=$SOURCE_SSL_MODE sslrootcert=/tls/certs/remote/ca.crt sslcert=/tls/certs/remote/client.crt sslkey=/tls/certs/remote/client.key'" >>/tmp/postgresql.conf
+    echo "primary_conninfo = 'application_name=$HOSTNAME host=$PRIMARY_HOST user=$PRIMARY_USER_NAME password=$PRIMARY_PASSWORD sslmode=$SOURCE_SSL_MODE sslrootcert=/tls/certs/remote/ca.crt sslcert=/tls/certs/remote/client.crt sslkey=/tls/certs/remote/client.key$CONNINFO_DBNAME'" >>/tmp/postgresql.conf
 else
-    echo "primary_conninfo = 'application_name=$HOSTNAME host=$PRIMARY_HOST user=$PRIMARY_USER_NAME password=$PRIMARY_PASSWORD'" >>/tmp/postgresql.conf
+    echo "primary_conninfo = 'application_name=$HOSTNAME host=$PRIMARY_HOST user=$PRIMARY_USER_NAME password=$PRIMARY_PASSWORD$CONNINFO_DBNAME'" >>/tmp/postgresql.conf
 fi
 
 cat /run_scripts/role/postgresql.conf >>/tmp/postgresql.conf

--- a/role_scripts/18/standby/run.sh
+++ b/role_scripts/18/standby/run.sh
@@ -217,14 +217,19 @@ fi
 # ****************** Recovery config **************************
 echo "recovery_target_timeline = 'latest'" >>/tmp/postgresql.conf
 # primary_conninfo is used for streaming replication
+CONNINFO_DBNAME=""
+if [[ "$WAL_LIMIT_POLICY" == "ReplicationSlot" ]]; then
+    CONNINFO_DBNAME=" dbname=postgres"
+fi
+
 if [[ "${SSL:-0}" == "ON" ]]; then
     if [[ "$CLIENT_AUTH_MODE" == "cert" ]]; then
-        echo "primary_conninfo = 'application_name=$HOSTNAME host=$PRIMARY_HOST user=$POSTGRES_USER password=$POSTGRES_PASSWORD sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key'" >>/tmp/postgresql.conf
+        echo "primary_conninfo = 'application_name=$HOSTNAME host=$PRIMARY_HOST user=$POSTGRES_USER password=$POSTGRES_PASSWORD sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key$CONNINFO_DBNAME'" >>/tmp/postgresql.conf
     else
-        echo "primary_conninfo = 'application_name=$HOSTNAME host=$PRIMARY_HOST user=$POSTGRES_USER password=$POSTGRES_PASSWORD sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt'" >>/tmp/postgresql.conf
+        echo "primary_conninfo = 'application_name=$HOSTNAME host=$PRIMARY_HOST user=$POSTGRES_USER password=$POSTGRES_PASSWORD sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt$CONNINFO_DBNAME'" >>/tmp/postgresql.conf
     fi
 else
-    echo "primary_conninfo = 'application_name=$HOSTNAME host=$PRIMARY_HOST user=$POSTGRES_USER password=$POSTGRES_PASSWORD'" >>/tmp/postgresql.conf
+    echo "primary_conninfo = 'application_name=$HOSTNAME host=$PRIMARY_HOST user=$POSTGRES_USER password=$POSTGRES_PASSWORD$CONNINFO_DBNAME'" >>/tmp/postgresql.conf
 fi
 
 cat /run_scripts/role/postgresql.conf >>/tmp/postgresql.conf

--- a/scripts/config_recovery.conf.sh
+++ b/scripts/config_recovery.conf.sh
@@ -6,19 +6,21 @@ echo "standby_mode = on" >>/tmp/recovery.conf
 echo "trigger_file = '/run_scripts/tmp/pg-failover-trigger'" >>/tmp/recovery.conf
 echo "recovery_target_timeline = 'latest'" >>/tmp/recovery.conf
 
+CONNINFO_DBNAME=""
 if [[ "$WAL_LIMIT_POLICY" == "ReplicationSlot" ]]; then
   CLEAN_HOSTNAME="${HOSTNAME//[^[:alnum:]]/}"
   echo "primary_slot_name = "$CLEAN_HOSTNAME"" >>/tmp/recovery.conf
+  CONNINFO_DBNAME=" dbname=postgres"
 fi
 # primary_conninfo is used for streaming replication
 if [[ "${SSL:-0}" == "ON" ]]; then
     if [[ "$CLIENT_AUTH_MODE" == "cert" ]]; then
-        echo "primary_conninfo = 'application_name=$HOSTNAME host=$PRIMARY_HOST user=$POSTGRES_USER password=$POSTGRES_PASSWORD sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key'" >>/tmp/recovery.conf
+        echo "primary_conninfo = 'application_name=$HOSTNAME host=$PRIMARY_HOST user=$POSTGRES_USER password=$POSTGRES_PASSWORD sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt sslcert=/tls/certs/client/client.crt sslkey=/tls/certs/client/client.key$CONNINFO_DBNAME'" >>/tmp/recovery.conf
     else
-        echo "primary_conninfo = 'application_name=$HOSTNAME host=$PRIMARY_HOST user=$POSTGRES_USER password=$POSTGRES_PASSWORD sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt'" >>/tmp/recovery.conf
+        echo "primary_conninfo = 'application_name=$HOSTNAME host=$PRIMARY_HOST user=$POSTGRES_USER password=$POSTGRES_PASSWORD sslmode=$SSL_MODE sslrootcert=/tls/certs/client/ca.crt$CONNINFO_DBNAME'" >>/tmp/recovery.conf
     fi
 else
-    echo "primary_conninfo = 'application_name=$HOSTNAME host=$PRIMARY_HOST user=$POSTGRES_USER password=$POSTGRES_PASSWORD'" >>/tmp/recovery.conf
+    echo "primary_conninfo = 'application_name=$HOSTNAME host=$PRIMARY_HOST user=$POSTGRES_USER password=$POSTGRES_PASSWORD$CONNINFO_DBNAME'" >>/tmp/recovery.conf
 fi
 
 mv /tmp/recovery.conf "$PGDATA/recovery.conf"


### PR DESCRIPTION
## Summary
- Add `dbname=postgres` to the `primary_conninfo` parameter when `WAL_LIMIT_POLICY` is set to `ReplicationSlot` for PG 17 and 18
- Ensures the standby connects to the postgres database for replication slot management

## Changes
- `role_scripts/17/primary/start.sh`: Add conditional dbname parameter
- `role_scripts/18/primary/start.sh`: Add conditional dbname parameter
- `scripts/config_recovery.conf.sh`: Add conditional dbname parameter

## Why
When using replication slots for WAL limit policy, the connection needs to explicitly specify the postgres database to ensure proper replication slot functionality.

🤖 Generated with Claude Code