### PR TITLE
Enable hot_standby when using ReplicationSlot WAL limit policy (v17–v18)

### DIFF
--- a/role_scripts/17/standby/run.sh
+++ b/role_scripts/17/standby/run.sh
@@ -163,7 +163,7 @@ fi
 
 echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
 
-if [ "$STANDBY" == "hot" ]; then
+if [[ "$WAL_LIMIT_POLICY" == "ReplicationSlot" ]] || [ "$STANDBY" == "hot" ]; then
     echo "hot_standby = on" >>/tmp/postgresql.conf
 else
     echo "hot_standby = off" >>/tmp/postgresql.conf

--- a/role_scripts/17/standby/warm_stanby.sh
+++ b/role_scripts/17/standby/warm_stanby.sh
@@ -37,7 +37,11 @@ echo "max_replication_slots = 90" >>/tmp/postgresql.conf
 echo "archive_mode = always" >>/tmp/postgresql.conf
 echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
 
-echo "hot_standby = off" >>/tmp/postgresql.conf
+if [[ "$WAL_LIMIT_POLICY" == "ReplicationSlot" ]]; then
+    echo "hot_standby = on" >>/tmp/postgresql.conf
+else
+    echo "hot_standby = off" >>/tmp/postgresql.conf
+fi
 
 echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
 

--- a/role_scripts/18/standby/run.sh
+++ b/role_scripts/18/standby/run.sh
@@ -163,7 +163,7 @@ fi
 
 echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
 
-if [ "$STANDBY" == "hot" ]; then
+if [[ "$WAL_LIMIT_POLICY" == "ReplicationSlot" ]] || [ "$STANDBY" == "hot" ]; then
     echo "hot_standby = on" >>/tmp/postgresql.conf
 else
     echo "hot_standby = off" >>/tmp/postgresql.conf

--- a/role_scripts/18/standby/warm_stanby.sh
+++ b/role_scripts/18/standby/warm_stanby.sh
@@ -37,7 +37,11 @@ echo "max_replication_slots = 90" >>/tmp/postgresql.conf
 echo "archive_mode = always" >>/tmp/postgresql.conf
 echo "archive_command = '/bin/true'" >>/tmp/postgresql.conf
 
-echo "hot_standby = off" >>/tmp/postgresql.conf
+if [[ "$WAL_LIMIT_POLICY" == "ReplicationSlot" ]]; then
+    echo "hot_standby = on" >>/tmp/postgresql.conf
+else
+    echo "hot_standby = off" >>/tmp/postgresql.conf
+fi
 
 echo "shared_preload_libraries = 'pg_stat_statements'" >>/tmp/postgresql.conf
 


### PR DESCRIPTION
## Summary

- Fixes standby startup failure when `WAL_LIMIT_POLICY=ReplicationSlot` due to existing logical replication slots requiring `hot_standby = on`
- Updates both fresh initialization (`run.sh`) and warm standby recovery (`warm_stanby.sh`) for versions 17 and 18
- Ensures consistency: `hot_standby` is now enabled when either `WAL_LIMIT_POLICY == "ReplicationSlot"` or `STANDBY == "hot"`

## Root cause

PostgreSQL refuses to start a standby with `hot_standby = off` if logical replication slots exist. The error was:
```
logical replication slot "ace_pgoutbox_slot" exists on the standby, but "hot_standby" = "off"
```

## Testing

- Verify standby starts successfully when `WAL_LIMIT_POLICY=ReplicationSlot` is set
- Verify hot standby mode still works when explicitly enabled via `STANDBY=hot`
- Verify non-replication-slot configurations continue to work as before