### PR TITLE
Exit the supervisor loop on SIGTERM instead of spinning until SIGKILL

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -2,14 +2,31 @@
 RECOVERY_DONE_FILE="/var/pv/"$PITR_UNIX_TIME"_recovery.done"
 PITR_RS=${PITR_REPLICATION_STRATEGY:-none}
 STOP=false
-# don't restart postgres on SIGTERM (eg, pod deleted)
+# don't restart postgres on SIGTERM (eg, pod deleted), and stop supervising once
+# the signal arrives, so this script (the container's main process) EXITS.
+#
+# The trap alone is not enough: it only tells the loop below not to start postgres
+# again. With `while true` the loop kept spinning forever after that, the container
+# never exited on its own, and kubelet had no choice but to wait out the whole
+# terminationGracePeriodSeconds and SIGKILL. Two consequences, both observed live:
+# pod deletions blocked for the entire grace period (5 minutes on a DB that sets
+# 300), and on the default 30s grace a postgres shutdown checkpoint slower than
+# that got SIGKILLed midway, leaving a data directory that needs crash recovery.
+#
+# STOP is only ever set by a signal delivered to THIS bash process, which in
+# practice means kubelet stopping the container. The coordinator stops postgres
+# with `pg_ctl stop` exec'd into the container (and kills nothing else by name or
+# process group), so its shutdowns do not reach this process: the loop keeps
+# retrying and re-runs the role script when the coordinator writes the next one,
+# exactly as before. Verified live: a single container instance served 17 role
+# script starts with no restart.
 # ref: https://opensource.com/article/20/6/bash-trap
 trap \
     "{ STOP=true; }" \
     SIGINT SIGTERM EXIT
 
 if [[ "$PITR_RESTORE" == "true" ]]; then
-    while true; do
+    while [[ "$STOP" = false ]]; do
       sleep 2
       echo "Point In Time Recovery In Progress. Waiting for $RECOVERY_DONE_FILE file"
       if [[ -e "$RECOVERY_DONE_FILE" ]]; then
@@ -22,7 +39,7 @@ fi
 #going to change this with the check of process id
 rm -f "$PGDATA"/postmaster.pid
 echo "waiting for the role to be decided ..."
-while true; do
+while [[ "$STOP" = false ]]; do
   # Robust /var/pv mount availability check before any destructive operation or basebackup
     if [[ -e /var/pv/BOOTSTRAP_INITIALIZATION_STARTED ]]; then
         rm /var/pv/BOOTSTRAP_INITIALIZATION_STARTED


### PR DESCRIPTION
## The bug

`scripts/run.sh` traps SIGTERM and sets `STOP=true`, but the loop condition is the
literal `true`; `STOP` is only consulted to decide whether to start postgres again:

```bash
trap "{ STOP=true; }" SIGINT SIGTERM EXIT
while true; do                                   # never re-evaluates STOP
    if [[ -e /run_scripts/role/run.sh ]] && [[ "$STOP" = false ]]; then ... fi
    sleep 1
done
```

So on SIGTERM the script does exactly what commit 06ba93a promised (stop restarting
postgres) and then spins forever. This script is the container's main process
(`tini -> bash run.sh -> postgres`), so the container can never exit on its own:
**every** termination ends in a SIGKILL at the end of `terminationGracePeriodSeconds`.

## Impact, observed live on a DC-DR pair

1. **Pod deletions block for the entire grace period.** A database with
   `terminationGracePeriodSeconds: 300` took 5 minutes to delete, idle almost the
   whole time. Its own logs show postgres finished shutting down at 09:03:35 and
   `run.sh` immediately printed `removing the initial scripts as server is not
   running ...` (the loop regaining control) — then nothing until the SIGKILL at
   09:07:34, exactly the deletion deadline.
2. **On the default 30s grace, postgres gets SIGKILLed mid-checkpoint.** A measured
   shutdown on a moderately busy instance took 42s. Past the ceiling the postmaster
   is killed part-way through its shutdown checkpoint, leaving a data directory that
   needs crash recovery — for a DC-DR primary, precisely the torn-checkpoint shape
   behind timeline divergence incidents.

## The fix

`while [[ "$STOP" = false ]]; do` (same for the PITR wait loop, which had the same
problem). After SIGTERM the current iteration finishes and the script exits, so the
container stops in about a second once postgres is down, and the grace period goes
back to being a ceiling rather than a fixed cost.

## Why this does not break the restart-on-role-change behavior

The concern is real and was checked before changing the line: pg-coordinator stops
postgres on its own (demote, fence, rewind), and the loop must keep retrying so the
next role script gets picked up. It still does, because **a bash trap only fires for
signals delivered to that bash process**, and no coordinator path signals it:

| coordinator path | what it runs | target |
| --- | --- | --- |
| `TerminatePostgres` (gRPC + fallback) | `pg_ctl -m fast\|immediate -w stop` exec'd into the postgres container | postmaster, by its own pidfile |
| `ShutDownCleanly` | same `pg_ctl` path | postmaster |
| `KillBaseBackupProcess` | scans `/proc/*/comm`, kills only where `comm == pg_basebackup` | pg_basebackup |
| reload / walreceiver stop | `kill -HUP $(head -1 postmaster.pid)`, `kill -TERM $walreceiver_pid` | postmaster / one backend |

No `pkill`, no `killall`, no process-group or pid-1 kill anywhere. Killing a *child*
only makes bash's `wait` return, which is the existing retry path.

**Live proof:** a single postgres container instance (restartCount unchanged) served
**17** `running the initial script ...` starts across many coordinator-driven role
changes. That is only possible if `STOP` stayed `false` the whole time — if any of
those kills had reached bash, the `[[ "$STOP" = false ]]` guard would have blocked
every subsequent start and postgres would never have come back.

Caveat for future readers: this holds because `tini` runs without `-g`. With group
mode, a container SIGTERM would also hit postgres directly and bypass the `pg_ctl`
fast-stop ordering.

## Testing

- `bash -n` clean.
- Sandbox reproduction of the old shape: still alive after SIGTERM, needed SIGKILL.
- Sandbox of the fixed shape: restarted the child twice (retry preserved), then
  exited on its own after SIGTERM.
- Live verification on a real cluster with a database built on this image: pending
  in the PR discussion (bootstrap, role transitions, and deletion timing).
