### PR TITLE
Support user-supplied pg_hba rules via configSecret key user_hba.conf

### DIFF
--- a/role_scripts/10/primary/start.sh
+++ b/role_scripts/10/primary/start.sh
@@ -253,6 +253,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            cert clientcert=1'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 cert clientcert=1'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
+
         { echo 'hostssl    all             all             0.0.0.0/0               cert clientcert=1'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               cert clientcert=1'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    cert clientcert=1'; } >>/tmp/pg_hba.conf
@@ -266,6 +277,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'local      replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
 
         { echo 'hostssl    all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
@@ -282,6 +304,17 @@ else
     { echo 'local        replication     all                                     trust'; } >>/tmp/pg_hba.conf
     { echo 'host         replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
     { echo 'host         replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+    # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+    # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+    # and after the local/loopback rules above, so custom rules can override the
+    # defaults but cannot lock out the operator's own scripts.
+    # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+    # copied in at generation time; secret changes take effect on pod restart.
+    if [[ -s /etc/config/user_hba.conf ]]; then
+        cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+        echo '' >>/tmp/pg_hba.conf
+    fi
 
     { echo 'host         all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
     { echo 'host         replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf

--- a/role_scripts/10/standby/run.sh
+++ b/role_scripts/10/standby/run.sh
@@ -234,6 +234,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            cert clientcert=1'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 cert clientcert=1'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
+
         { echo 'hostssl    all             all             0.0.0.0/0               cert clientcert=1'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               cert clientcert=1'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    cert clientcert=1'; } >>/tmp/pg_hba.conf
@@ -247,6 +258,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'local      replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
 
         { echo 'hostssl    all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
@@ -263,6 +285,17 @@ else
     { echo 'local        replication     all                                     trust'; } >>/tmp/pg_hba.conf
     { echo 'host         replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
     { echo 'host         replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+    # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+    # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+    # and after the local/loopback rules above, so custom rules can override the
+    # defaults but cannot lock out the operator's own scripts.
+    # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+    # copied in at generation time; secret changes take effect on pod restart.
+    if [[ -s /etc/config/user_hba.conf ]]; then
+        cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+        echo '' >>/tmp/pg_hba.conf
+    fi
 
     { echo 'host         all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
     { echo 'host         replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf

--- a/role_scripts/11/primary/start.sh
+++ b/role_scripts/11/primary/start.sh
@@ -263,6 +263,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            cert clientcert=1'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 cert clientcert=1'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
+
         { echo 'hostssl    all             all             0.0.0.0/0               cert clientcert=1'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               cert clientcert=1'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    cert clientcert=1'; } >>/tmp/pg_hba.conf
@@ -277,6 +288,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 scram-sha-256'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
+
         { echo 'hostssl    all             all             0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    scram-sha-256'; } >>/tmp/pg_hba.conf
@@ -290,6 +312,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'local      replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
 
         { echo 'hostssl    all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
@@ -308,6 +341,17 @@ else
         { echo 'host         replication     all             127.0.0.1/32            scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             ::1/128                 scram-sha-256'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
+
         { echo 'host         all             all             0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     postgres        0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         all             all             ::/0                    scram-sha-256'; } >>/tmp/pg_hba.conf
@@ -321,6 +365,17 @@ else
         { echo 'local        replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
 
         { echo 'host         all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf

--- a/role_scripts/11/standby/run.sh
+++ b/role_scripts/11/standby/run.sh
@@ -242,6 +242,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            cert clientcert=1'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 cert clientcert=1'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
+
         { echo 'hostssl    all             all             0.0.0.0/0               cert clientcert=1'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               cert clientcert=1'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    cert clientcert=1'; } >>/tmp/pg_hba.conf
@@ -256,6 +267,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 scram-sha-256'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
+
         { echo 'hostssl    all             all             0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    scram-sha-256'; } >>/tmp/pg_hba.conf
@@ -269,6 +291,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'local      replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
 
         { echo 'hostssl    all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
@@ -287,6 +320,17 @@ else
         { echo 'host         replication     all             127.0.0.1/32            scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             ::1/128                 scram-sha-256'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
+
         { echo 'host         all             all             0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     postgres        0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         all             all             ::/0                    scram-sha-256'; } >>/tmp/pg_hba.conf
@@ -300,6 +344,17 @@ else
         { echo 'local        replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
 
         { echo 'host         all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf

--- a/role_scripts/12/primary/start.sh
+++ b/role_scripts/12/primary/start.sh
@@ -283,6 +283,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            cert clientcert=1'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 cert clientcert=1'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
+
         { echo 'hostssl    all             all             0.0.0.0/0               cert clientcert=1'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               cert clientcert=1'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    cert clientcert=1'; } >>/tmp/pg_hba.conf
@@ -297,6 +308,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 scram-sha-256'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
+
         { echo 'hostssl    all             all             0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    scram-sha-256'; } >>/tmp/pg_hba.conf
@@ -310,6 +332,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'local      replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
 
         { echo 'hostssl    all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
@@ -328,6 +361,17 @@ else
         { echo 'host         replication     all             127.0.0.1/32            scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             ::1/128                 scram-sha-256'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
+
         { echo 'host         all             all             0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     postgres        0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         all             all             ::/0                    scram-sha-256'; } >>/tmp/pg_hba.conf
@@ -341,6 +385,17 @@ else
         { echo 'local        replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
 
         { echo 'host         all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf

--- a/role_scripts/12/standby/run.sh
+++ b/role_scripts/12/standby/run.sh
@@ -257,6 +257,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            cert clientcert=1'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 cert clientcert=1'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
+
         { echo 'hostssl    all             all             0.0.0.0/0               cert clientcert=1'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               cert clientcert=1'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    cert clientcert=1'; } >>/tmp/pg_hba.conf
@@ -271,6 +282,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 scram-sha-256'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
+
         { echo 'hostssl    all             all             0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    scram-sha-256'; } >>/tmp/pg_hba.conf
@@ -284,6 +306,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'local      replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
 
         { echo 'hostssl    all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
@@ -302,6 +335,17 @@ else
         { echo 'host         replication     all             127.0.0.1/32            scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             ::1/128                 scram-sha-256'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
+
         { echo 'host         all             all             0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     postgres        0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         all             all             ::/0                    scram-sha-256'; } >>/tmp/pg_hba.conf
@@ -315,6 +359,17 @@ else
         { echo 'local        replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
 
         { echo 'host         all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf

--- a/role_scripts/13/primary/start.sh
+++ b/role_scripts/13/primary/start.sh
@@ -304,6 +304,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
+
         { echo 'hostssl    all             all             0.0.0.0/0               cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
@@ -320,6 +331,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 scram-sha-256'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
+
         { echo 'hostssl    all             all             0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    scram-sha-256'; } >>/tmp/pg_hba.conf
@@ -335,6 +357,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'local      replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
 
         { echo 'hostssl    all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
@@ -355,6 +388,17 @@ else
         { echo 'host         replication     all             127.0.0.1/32            scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             ::1/128                 scram-sha-256'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
+
         { echo 'host         all             all             0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     postgres        0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         all             all             ::/0                    scram-sha-256'; } >>/tmp/pg_hba.conf
@@ -370,6 +414,17 @@ else
         { echo 'local        replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
 
         { echo 'host         all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf

--- a/role_scripts/13/standby/remote-replica.sh
+++ b/role_scripts/13/standby/remote-replica.sh
@@ -174,6 +174,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
+
         { echo 'hostssl    all             all             0.0.0.0/0               cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
@@ -188,6 +199,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 scram-sha-256'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
+
         { echo 'hostssl    all             all             0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    scram-sha-256'; } >>/tmp/pg_hba.conf
@@ -201,6 +223,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'local      replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
 
         { echo 'hostssl    all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
@@ -219,6 +252,17 @@ else
         { echo 'host         replication     all             127.0.0.1/32            scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             ::1/128                 scram-sha-256'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
+
         { echo 'host         all             all             0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     postgres        0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         all             all             ::/0                    scram-sha-256'; } >>/tmp/pg_hba.conf
@@ -232,6 +276,17 @@ else
         { echo 'local        replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
 
         { echo 'host         all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf

--- a/role_scripts/13/standby/run.sh
+++ b/role_scripts/13/standby/run.sh
@@ -263,6 +263,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
+
         { echo 'hostssl    all             all             0.0.0.0/0               cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
@@ -279,6 +290,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 scram-sha-256'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
+
         { echo 'hostssl    all             all             0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    scram-sha-256'; } >>/tmp/pg_hba.conf
@@ -294,6 +316,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'local      replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
 
         { echo 'hostssl    all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
@@ -314,6 +347,17 @@ else
         { echo 'host         replication     all             127.0.0.1/32            scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             ::1/128                 scram-sha-256'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
+
         { echo 'host         all             all             0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     postgres        0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         all             all             ::/0                    scram-sha-256'; } >>/tmp/pg_hba.conf
@@ -329,6 +373,17 @@ else
         { echo 'local        replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
 
         { echo 'host         all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf

--- a/role_scripts/14/primary/start.sh
+++ b/role_scripts/14/primary/start.sh
@@ -308,6 +308,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
+
         { echo 'hostssl    all             all             0.0.0.0/0               cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
@@ -324,6 +335,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 scram-sha-256'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
+
         { echo 'hostssl    all             all             0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    scram-sha-256'; } >>/tmp/pg_hba.conf
@@ -339,6 +361,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'local      replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
 
         { echo 'hostssl    all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
@@ -359,6 +392,17 @@ else
         { echo 'host         replication     all             127.0.0.1/32            scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             ::1/128                 scram-sha-256'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
+
         { echo 'host         all             all             0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     postgres        0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         all             all             ::/0                    scram-sha-256'; } >>/tmp/pg_hba.conf
@@ -374,6 +418,17 @@ else
         { echo 'local        replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
 
         { echo 'host         all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf

--- a/role_scripts/14/standby/remote-replica.sh
+++ b/role_scripts/14/standby/remote-replica.sh
@@ -174,6 +174,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
+
         { echo 'hostssl    all             all             0.0.0.0/0               cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
@@ -188,6 +199,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 scram-sha-256'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
+
         { echo 'hostssl    all             all             0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    scram-sha-256'; } >>/tmp/pg_hba.conf
@@ -201,6 +223,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'local      replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
 
         { echo 'hostssl    all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
@@ -219,6 +252,17 @@ else
         { echo 'host         replication     all             127.0.0.1/32            scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             ::1/128                 scram-sha-256'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
+
         { echo 'host         all             all             0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     postgres        0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         all             all             ::/0                    scram-sha-256'; } >>/tmp/pg_hba.conf
@@ -232,6 +276,17 @@ else
         { echo 'local        replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
 
         { echo 'host         all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf

--- a/role_scripts/14/standby/run.sh
+++ b/role_scripts/14/standby/run.sh
@@ -263,6 +263,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
+
         { echo 'hostssl    all             all             0.0.0.0/0               cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
@@ -279,6 +290,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 scram-sha-256'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
+
         { echo 'hostssl    all             all             0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    scram-sha-256'; } >>/tmp/pg_hba.conf
@@ -294,6 +316,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'local      replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
 
         { echo 'hostssl    all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
@@ -314,6 +347,17 @@ else
         { echo 'host         replication     all             127.0.0.1/32            scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             ::1/128                 scram-sha-256'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
+
         { echo 'host         all             all             0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     postgres        0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         all             all             ::/0                    scram-sha-256'; } >>/tmp/pg_hba.conf
@@ -329,6 +373,17 @@ else
         { echo 'local        replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
 
         { echo 'host         all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf

--- a/role_scripts/15/primary/start.sh
+++ b/role_scripts/15/primary/start.sh
@@ -311,6 +311,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
+
         { echo 'hostssl    all             all             0.0.0.0/0               cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
@@ -327,6 +338,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 scram-sha-256'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
+
         { echo 'hostssl    all             all             0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    scram-sha-256'; } >>/tmp/pg_hba.conf
@@ -342,6 +364,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'local      replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
 
         { echo 'hostssl    all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
@@ -362,6 +395,17 @@ else
         { echo 'host         replication     all             127.0.0.1/32            scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             ::1/128                 scram-sha-256'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
+
         { echo 'host         all             all             0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     postgres        0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         all             all             ::/0                    scram-sha-256'; } >>/tmp/pg_hba.conf
@@ -377,6 +421,17 @@ else
         { echo 'local        replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
 
         { echo 'host         all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf

--- a/role_scripts/15/standby/remote-replica.sh
+++ b/role_scripts/15/standby/remote-replica.sh
@@ -174,6 +174,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
+
         { echo 'hostssl    all             all             0.0.0.0/0               cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
@@ -188,6 +199,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 scram-sha-256'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
+
         { echo 'hostssl    all             all             0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    scram-sha-256'; } >>/tmp/pg_hba.conf
@@ -201,6 +223,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'local      replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
 
         { echo 'hostssl    all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
@@ -219,6 +252,17 @@ else
         { echo 'host         replication     all             127.0.0.1/32            scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             ::1/128                 scram-sha-256'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
+
         { echo 'host         all             all             0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     postgres        0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         all             all             ::/0                    scram-sha-256'; } >>/tmp/pg_hba.conf
@@ -232,6 +276,17 @@ else
         { echo 'local        replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
 
         { echo 'host         all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf

--- a/role_scripts/15/standby/run.sh
+++ b/role_scripts/15/standby/run.sh
@@ -262,6 +262,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
+
         { echo 'hostssl    all             all             0.0.0.0/0               cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
@@ -278,6 +289,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 scram-sha-256'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
+
         { echo 'hostssl    all             all             0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    scram-sha-256'; } >>/tmp/pg_hba.conf
@@ -293,6 +315,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'local      replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
 
         { echo 'hostssl    all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
@@ -313,6 +346,17 @@ else
         { echo 'host         replication     all             127.0.0.1/32            scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             ::1/128                 scram-sha-256'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
+
         { echo 'host         all             all             0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     postgres        0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         all             all             ::/0                    scram-sha-256'; } >>/tmp/pg_hba.conf
@@ -328,6 +372,17 @@ else
         { echo 'local        replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
 
         { echo 'host         all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf

--- a/role_scripts/16/primary/start.sh
+++ b/role_scripts/16/primary/start.sh
@@ -310,6 +310,13 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # include_if_exists (PostgreSQL 16+): secret updates apply on config reload.
+        { echo 'include_if_exists "/etc/config/user_hba.conf"'; } >>/tmp/pg_hba.conf
+
         { echo 'hostssl    all             all             0.0.0.0/0               cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
@@ -326,6 +333,13 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 scram-sha-256'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # include_if_exists (PostgreSQL 16+): secret updates apply on config reload.
+        { echo 'include_if_exists "/etc/config/user_hba.conf"'; } >>/tmp/pg_hba.conf
+
         { echo 'hostssl    all             all             0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    scram-sha-256'; } >>/tmp/pg_hba.conf
@@ -341,6 +355,13 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'local      replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # include_if_exists (PostgreSQL 16+): secret updates apply on config reload.
+        { echo 'include_if_exists "/etc/config/user_hba.conf"'; } >>/tmp/pg_hba.conf
 
         { echo 'hostssl    all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
@@ -361,6 +382,13 @@ else
         { echo 'host         replication     all             127.0.0.1/32            scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             ::1/128                 scram-sha-256'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # include_if_exists (PostgreSQL 16+): secret updates apply on config reload.
+        { echo 'include_if_exists "/etc/config/user_hba.conf"'; } >>/tmp/pg_hba.conf
+
         { echo 'host         all             all             0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     postgres        0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         all             all             ::/0                    scram-sha-256'; } >>/tmp/pg_hba.conf
@@ -376,6 +404,13 @@ else
         { echo 'local        replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # include_if_exists (PostgreSQL 16+): secret updates apply on config reload.
+        { echo 'include_if_exists "/etc/config/user_hba.conf"'; } >>/tmp/pg_hba.conf
 
         { echo 'host         all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf

--- a/role_scripts/16/standby/remote-replica.sh
+++ b/role_scripts/16/standby/remote-replica.sh
@@ -172,6 +172,13 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # include_if_exists (PostgreSQL 16+): secret updates apply on config reload.
+        { echo 'include_if_exists "/etc/config/user_hba.conf"'; } >>/tmp/pg_hba.conf
+
         { echo 'hostssl    all             all             0.0.0.0/0               cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
@@ -186,6 +193,13 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 scram-sha-256'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # include_if_exists (PostgreSQL 16+): secret updates apply on config reload.
+        { echo 'include_if_exists "/etc/config/user_hba.conf"'; } >>/tmp/pg_hba.conf
+
         { echo 'hostssl    all             all             0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    scram-sha-256'; } >>/tmp/pg_hba.conf
@@ -199,6 +213,13 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'local      replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # include_if_exists (PostgreSQL 16+): secret updates apply on config reload.
+        { echo 'include_if_exists "/etc/config/user_hba.conf"'; } >>/tmp/pg_hba.conf
 
         { echo 'hostssl    all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
@@ -217,6 +238,13 @@ else
         { echo 'host         replication     all             127.0.0.1/32            scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             ::1/128                 scram-sha-256'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # include_if_exists (PostgreSQL 16+): secret updates apply on config reload.
+        { echo 'include_if_exists "/etc/config/user_hba.conf"'; } >>/tmp/pg_hba.conf
+
         { echo 'host         all             all             0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     postgres        0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         all             all             ::/0                    scram-sha-256'; } >>/tmp/pg_hba.conf
@@ -230,6 +258,13 @@ else
         { echo 'local        replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # include_if_exists (PostgreSQL 16+): secret updates apply on config reload.
+        { echo 'include_if_exists "/etc/config/user_hba.conf"'; } >>/tmp/pg_hba.conf
 
         { echo 'host         all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf

--- a/role_scripts/16/standby/run.sh
+++ b/role_scripts/16/standby/run.sh
@@ -261,6 +261,13 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # include_if_exists (PostgreSQL 16+): secret updates apply on config reload.
+        { echo 'include_if_exists "/etc/config/user_hba.conf"'; } >>/tmp/pg_hba.conf
+
         { echo 'hostssl    all             all             0.0.0.0/0               cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
@@ -277,6 +284,13 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 scram-sha-256'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # include_if_exists (PostgreSQL 16+): secret updates apply on config reload.
+        { echo 'include_if_exists "/etc/config/user_hba.conf"'; } >>/tmp/pg_hba.conf
+
         { echo 'hostssl    all             all             0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    scram-sha-256'; } >>/tmp/pg_hba.conf
@@ -292,6 +306,13 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'local      replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # include_if_exists (PostgreSQL 16+): secret updates apply on config reload.
+        { echo 'include_if_exists "/etc/config/user_hba.conf"'; } >>/tmp/pg_hba.conf
 
         { echo 'hostssl    all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
@@ -312,6 +333,13 @@ else
         { echo 'host         replication     all             127.0.0.1/32            scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             ::1/128                 scram-sha-256'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # include_if_exists (PostgreSQL 16+): secret updates apply on config reload.
+        { echo 'include_if_exists "/etc/config/user_hba.conf"'; } >>/tmp/pg_hba.conf
+
         { echo 'host         all             all             0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     postgres        0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         all             all             ::/0                    scram-sha-256'; } >>/tmp/pg_hba.conf
@@ -327,6 +355,13 @@ else
         { echo 'local        replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # include_if_exists (PostgreSQL 16+): secret updates apply on config reload.
+        { echo 'include_if_exists "/etc/config/user_hba.conf"'; } >>/tmp/pg_hba.conf
 
         { echo 'host         all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf

--- a/role_scripts/17/primary/start.sh
+++ b/role_scripts/17/primary/start.sh
@@ -320,6 +320,13 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # include_if_exists (PostgreSQL 16+): secret updates apply on config reload.
+        { echo 'include_if_exists "/etc/config/user_hba.conf"'; } >>/tmp/pg_hba.conf
+
         { echo 'hostssl    all             all             0.0.0.0/0               cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
@@ -336,6 +343,13 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 scram-sha-256'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # include_if_exists (PostgreSQL 16+): secret updates apply on config reload.
+        { echo 'include_if_exists "/etc/config/user_hba.conf"'; } >>/tmp/pg_hba.conf
+
         { echo 'hostssl    all             all             0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    scram-sha-256'; } >>/tmp/pg_hba.conf
@@ -351,6 +365,13 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'local      replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # include_if_exists (PostgreSQL 16+): secret updates apply on config reload.
+        { echo 'include_if_exists "/etc/config/user_hba.conf"'; } >>/tmp/pg_hba.conf
 
         { echo 'hostssl    all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
@@ -371,6 +392,13 @@ else
         { echo 'host         replication     all             127.0.0.1/32            scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             ::1/128                 scram-sha-256'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # include_if_exists (PostgreSQL 16+): secret updates apply on config reload.
+        { echo 'include_if_exists "/etc/config/user_hba.conf"'; } >>/tmp/pg_hba.conf
+
         { echo 'host         all             all             0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     postgres        0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         all             all             ::/0                    scram-sha-256'; } >>/tmp/pg_hba.conf
@@ -386,6 +414,13 @@ else
         { echo 'local        replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # include_if_exists (PostgreSQL 16+): secret updates apply on config reload.
+        { echo 'include_if_exists "/etc/config/user_hba.conf"'; } >>/tmp/pg_hba.conf
 
         { echo 'host         all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf

--- a/role_scripts/17/standby/remote-replica.sh
+++ b/role_scripts/17/standby/remote-replica.sh
@@ -177,6 +177,13 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # include_if_exists (PostgreSQL 16+): secret updates apply on config reload.
+        { echo 'include_if_exists "/etc/config/user_hba.conf"'; } >>/tmp/pg_hba.conf
+
         { echo 'hostssl    all             all             0.0.0.0/0               cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
@@ -191,6 +198,13 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 scram-sha-256'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # include_if_exists (PostgreSQL 16+): secret updates apply on config reload.
+        { echo 'include_if_exists "/etc/config/user_hba.conf"'; } >>/tmp/pg_hba.conf
+
         { echo 'hostssl    all             all             0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    scram-sha-256'; } >>/tmp/pg_hba.conf
@@ -204,6 +218,13 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'local      replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # include_if_exists (PostgreSQL 16+): secret updates apply on config reload.
+        { echo 'include_if_exists "/etc/config/user_hba.conf"'; } >>/tmp/pg_hba.conf
 
         { echo 'hostssl    all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
@@ -222,6 +243,13 @@ else
         { echo 'host         replication     all             127.0.0.1/32            scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             ::1/128                 scram-sha-256'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # include_if_exists (PostgreSQL 16+): secret updates apply on config reload.
+        { echo 'include_if_exists "/etc/config/user_hba.conf"'; } >>/tmp/pg_hba.conf
+
         { echo 'host         all             all             0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     postgres        0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         all             all             ::/0                    scram-sha-256'; } >>/tmp/pg_hba.conf
@@ -235,6 +263,13 @@ else
         { echo 'local        replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # include_if_exists (PostgreSQL 16+): secret updates apply on config reload.
+        { echo 'include_if_exists "/etc/config/user_hba.conf"'; } >>/tmp/pg_hba.conf
 
         { echo 'host         all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf

--- a/role_scripts/17/standby/run.sh
+++ b/role_scripts/17/standby/run.sh
@@ -266,6 +266,13 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # include_if_exists (PostgreSQL 16+): secret updates apply on config reload.
+        { echo 'include_if_exists "/etc/config/user_hba.conf"'; } >>/tmp/pg_hba.conf
+
         { echo 'hostssl    all             all             0.0.0.0/0               cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
@@ -282,6 +289,13 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 scram-sha-256'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # include_if_exists (PostgreSQL 16+): secret updates apply on config reload.
+        { echo 'include_if_exists "/etc/config/user_hba.conf"'; } >>/tmp/pg_hba.conf
+
         { echo 'hostssl    all             all             0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    scram-sha-256'; } >>/tmp/pg_hba.conf
@@ -297,6 +311,13 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'local      replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # include_if_exists (PostgreSQL 16+): secret updates apply on config reload.
+        { echo 'include_if_exists "/etc/config/user_hba.conf"'; } >>/tmp/pg_hba.conf
 
         { echo 'hostssl    all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
@@ -317,6 +338,13 @@ else
         { echo 'host         replication     all             127.0.0.1/32            scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             ::1/128                 scram-sha-256'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # include_if_exists (PostgreSQL 16+): secret updates apply on config reload.
+        { echo 'include_if_exists "/etc/config/user_hba.conf"'; } >>/tmp/pg_hba.conf
+
         { echo 'host         all             all             0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     postgres        0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         all             all             ::/0                    scram-sha-256'; } >>/tmp/pg_hba.conf
@@ -332,6 +360,13 @@ else
         { echo 'local        replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # include_if_exists (PostgreSQL 16+): secret updates apply on config reload.
+        { echo 'include_if_exists "/etc/config/user_hba.conf"'; } >>/tmp/pg_hba.conf
 
         { echo 'host         all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf

--- a/role_scripts/18/primary/start.sh
+++ b/role_scripts/18/primary/start.sh
@@ -313,6 +313,13 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # include_if_exists (PostgreSQL 16+): secret updates apply on config reload.
+        { echo 'include_if_exists "/etc/config/user_hba.conf"'; } >>/tmp/pg_hba.conf
+
         { echo 'hostssl    all             all             0.0.0.0/0               cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
@@ -329,6 +336,13 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 scram-sha-256'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # include_if_exists (PostgreSQL 16+): secret updates apply on config reload.
+        { echo 'include_if_exists "/etc/config/user_hba.conf"'; } >>/tmp/pg_hba.conf
+
         { echo 'hostssl    all             all             0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    scram-sha-256'; } >>/tmp/pg_hba.conf
@@ -344,6 +358,13 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'local      replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # include_if_exists (PostgreSQL 16+): secret updates apply on config reload.
+        { echo 'include_if_exists "/etc/config/user_hba.conf"'; } >>/tmp/pg_hba.conf
 
         { echo 'hostssl    all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
@@ -364,6 +385,13 @@ else
         { echo 'host         replication     all             127.0.0.1/32            scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             ::1/128                 scram-sha-256'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # include_if_exists (PostgreSQL 16+): secret updates apply on config reload.
+        { echo 'include_if_exists "/etc/config/user_hba.conf"'; } >>/tmp/pg_hba.conf
+
         { echo 'host         all             all             0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     postgres        0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         all             all             ::/0                    scram-sha-256'; } >>/tmp/pg_hba.conf
@@ -379,6 +407,13 @@ else
         { echo 'local        replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # include_if_exists (PostgreSQL 16+): secret updates apply on config reload.
+        { echo 'include_if_exists "/etc/config/user_hba.conf"'; } >>/tmp/pg_hba.conf
 
         { echo 'host         all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf

--- a/role_scripts/18/standby/remote-replica.sh
+++ b/role_scripts/18/standby/remote-replica.sh
@@ -177,6 +177,13 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # include_if_exists (PostgreSQL 16+): secret updates apply on config reload.
+        { echo 'include_if_exists "/etc/config/user_hba.conf"'; } >>/tmp/pg_hba.conf
+
         { echo 'hostssl    all             all             0.0.0.0/0               cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
@@ -191,6 +198,13 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 scram-sha-256'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # include_if_exists (PostgreSQL 16+): secret updates apply on config reload.
+        { echo 'include_if_exists "/etc/config/user_hba.conf"'; } >>/tmp/pg_hba.conf
+
         { echo 'hostssl    all             all             0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    scram-sha-256'; } >>/tmp/pg_hba.conf
@@ -204,6 +218,13 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'local      replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # include_if_exists (PostgreSQL 16+): secret updates apply on config reload.
+        { echo 'include_if_exists "/etc/config/user_hba.conf"'; } >>/tmp/pg_hba.conf
 
         { echo 'hostssl    all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
@@ -222,6 +243,13 @@ else
         { echo 'host         replication     all             127.0.0.1/32            scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             ::1/128                 scram-sha-256'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # include_if_exists (PostgreSQL 16+): secret updates apply on config reload.
+        { echo 'include_if_exists "/etc/config/user_hba.conf"'; } >>/tmp/pg_hba.conf
+
         { echo 'host         all             all             0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     postgres        0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         all             all             ::/0                    scram-sha-256'; } >>/tmp/pg_hba.conf
@@ -235,6 +263,13 @@ else
         { echo 'local        replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # include_if_exists (PostgreSQL 16+): secret updates apply on config reload.
+        { echo 'include_if_exists "/etc/config/user_hba.conf"'; } >>/tmp/pg_hba.conf
 
         { echo 'host         all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf

--- a/role_scripts/18/standby/run.sh
+++ b/role_scripts/18/standby/run.sh
@@ -266,6 +266,13 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # include_if_exists (PostgreSQL 16+): secret updates apply on config reload.
+        { echo 'include_if_exists "/etc/config/user_hba.conf"'; } >>/tmp/pg_hba.conf
+
         { echo 'hostssl    all             all             0.0.0.0/0               cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    cert clientcert=verify-full'; } >>/tmp/pg_hba.conf
@@ -282,6 +289,13 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 scram-sha-256'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # include_if_exists (PostgreSQL 16+): secret updates apply on config reload.
+        { echo 'include_if_exists "/etc/config/user_hba.conf"'; } >>/tmp/pg_hba.conf
+
         { echo 'hostssl    all             all             0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    scram-sha-256'; } >>/tmp/pg_hba.conf
@@ -297,6 +311,13 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'local      replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # include_if_exists (PostgreSQL 16+): secret updates apply on config reload.
+        { echo 'include_if_exists "/etc/config/user_hba.conf"'; } >>/tmp/pg_hba.conf
 
         { echo 'hostssl    all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
@@ -317,6 +338,13 @@ else
         { echo 'host         replication     all             127.0.0.1/32            scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             ::1/128                 scram-sha-256'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # include_if_exists (PostgreSQL 16+): secret updates apply on config reload.
+        { echo 'include_if_exists "/etc/config/user_hba.conf"'; } >>/tmp/pg_hba.conf
+
         { echo 'host         all             all             0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     postgres        0.0.0.0/0               scram-sha-256'; } >>/tmp/pg_hba.conf
         { echo 'host         all             all             ::/0                    scram-sha-256'; } >>/tmp/pg_hba.conf
@@ -332,6 +360,13 @@ else
         { echo 'local        replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # include_if_exists (PostgreSQL 16+): secret updates apply on config reload.
+        { echo 'include_if_exists "/etc/config/user_hba.conf"'; } >>/tmp/pg_hba.conf
 
         { echo 'host         all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'host         replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf

--- a/role_scripts/9/primary/start.sh
+++ b/role_scripts/9/primary/start.sh
@@ -248,6 +248,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            cert clientcert=1'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 cert clientcert=1'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
+
         { echo 'hostssl    all             all             0.0.0.0/0               cert clientcert=1'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               cert clientcert=1'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    cert clientcert=1'; } >>/tmp/pg_hba.conf
@@ -261,6 +272,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'local      replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
 
         { echo 'hostssl    all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
@@ -277,6 +299,17 @@ else
     { echo 'local        replication     all                                     trust'; } >>/tmp/pg_hba.conf
     { echo 'host         replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
     { echo 'host         replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+    # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+    # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+    # and after the local/loopback rules above, so custom rules can override the
+    # defaults but cannot lock out the operator's own scripts.
+    # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+    # copied in at generation time; secret changes take effect on pod restart.
+    if [[ -s /etc/config/user_hba.conf ]]; then
+        cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+        echo '' >>/tmp/pg_hba.conf
+    fi
 
     { echo 'host         all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
     { echo 'host         replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf

--- a/role_scripts/9/standby/run.sh
+++ b/role_scripts/9/standby/run.sh
@@ -231,6 +231,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'hostssl    replication     all             127.0.0.1/32            cert clientcert=1'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 cert clientcert=1'; } >>/tmp/pg_hba.conf
 
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
+
         { echo 'hostssl    all             all             0.0.0.0/0               cert clientcert=1'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               cert clientcert=1'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    all             all             ::/0                    cert clientcert=1'; } >>/tmp/pg_hba.conf
@@ -244,6 +255,17 @@ if [[ "${SSL:-0}" == "ON" ]]; then
         { echo 'local      replication     all                                     trust'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+        # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+        # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+        # and after the local/loopback rules above, so custom rules can override the
+        # defaults but cannot lock out the operator's own scripts.
+        # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+        # copied in at generation time; secret changes take effect on pod restart.
+        if [[ -s /etc/config/user_hba.conf ]]; then
+            cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+            echo '' >>/tmp/pg_hba.conf
+        fi
 
         { echo 'hostssl    all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
         { echo 'hostssl    replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
@@ -260,6 +282,17 @@ else
     { echo 'local        replication     all                                     trust'; } >>/tmp/pg_hba.conf
     { echo 'host         replication     all             127.0.0.1/32            md5'; } >>/tmp/pg_hba.conf
     { echo 'host         replication     all             ::1/128                 md5'; } >>/tmp/pg_hba.conf
+
+    # KubeDB: user-supplied pg_hba rules (configSecret key: user_hba.conf).
+    # They go before the catch-all rules below (pg_hba.conf is first-match-wins)
+    # and after the local/loopback rules above, so custom rules can override the
+    # defaults but cannot lock out the operator's own scripts.
+    # PostgreSQL <= 15 cannot include files from pg_hba.conf, so the content is
+    # copied in at generation time; secret changes take effect on pod restart.
+    if [[ -s /etc/config/user_hba.conf ]]; then
+        cat /etc/config/user_hba.conf >>/tmp/pg_hba.conf
+        echo '' >>/tmp/pg_hba.conf
+    fi
 
     { echo 'host         all             all             0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf
     { echo 'host         replication     postgres        0.0.0.0/0               md5'; } >>/tmp/pg_hba.conf


### PR DESCRIPTION
Users have had no way to add `pg_hba.conf` rules: the role scripts regenerate the file from scratch on every pod start, and since `pg_hba.conf` is first-match-wins, appending at the end (the analogue of `postgresql.conf`'s trailing `include_if_exists`, which is last-wins) would leave user rules dead behind the generated `host all all 0.0.0.0/0` catch-alls.

This splices `/etc/config/user_hba.conf` (projected by the operator from the Postgres configSecret) into **every generation branch at a fixed position**: after the local/loopback and loopback-replication rules the operator's own scripts and sidecars depend on, and before the world-CIDR catch-alls. User rules can override the catch-alls — e.g. reject the `postgres` role from outside the pod network — but cannot lock the operator out.

**Version-gated mechanism** (both paths verified empirically):
- **PG ≥ 16**: emits `include_if_exists "/etc/config/user_hba.conf"` — secret updates apply on `pg_reload_conf()`, no restart; missing file tolerated at startup and reload. The double quotes are load-bearing: a single-quoted token is treated as a literal filename and skipped **silently**.
- **PG ≤ 15**: an include line is `FATAL: could not load pg_hba.conf` at startup (verified on 15-alpine), so the file content is concatenated at generation time; changes apply on pod restart.

**Scope**: `primary/start.sh`, `standby/run.sh`, `standby/remote-replica.sh` (long-running servers). `warm_stanby.sh`/`ha_backup_job.sh`/`restore.sh` are deliberately untouched — they run postgres for seconds during bootstrap/restore, where a user rule breaking recovery costs more than a seconds-long window of default rules protects.

**Verification**: a harness executed the generation section of all 26 modified scripts and their master counterparts under all five SSL/CLIENT_AUTH_MODE combos, with and without the user file — 260/260:
- file absent: PG ≤ 15 output byte-identical to master; PG ≥ 16 differs by exactly the include line
- file present: rules appear exactly once, after the essentials, before the first catch-all, in every branch

Companion PRs: kubedb/apimachinery (constant), kubedb/postgres (projects the key), kubedb/docs (guide, including the pod-CIDR-allow-before-reject pattern that keeps pg-coordinator's peer connections as `postgres` working).